### PR TITLE
Script.timers.3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # kodi-addon-timers
 Powerful timers for KODI
 
-I wanted to have a Kodi addon that is a sleep timer, a doze timer, has several other timer slots and combines it with fading volume in and out over a certain period. Since I haven't found it I decided to program it by myself.
+I wanted to have a KODI addon that is a sleep timer, a doze timer, has several other timer slots and combines it with fading volume in and out over a certain period. Since I haven't found it I decided to program it by myself.
 
 The result is a powerful timer addon.
 
 ## Overview of features:
 * Unlimited timer slots. All of them can be quickly set up by using context menu
 * single-click-setup for sleep and doze timers
-* Timers can play any resource that it available in Kodi, e.g. music folders, video files, TV/radio programs, slideshows, ressources from 3rd party plugins, e.g. Zattoo channels.
+* Timers can play any resource that it available in KODI, e.g. music folders, video files, TV/radio programs, slideshows, resources from 3rd party plugins, e.g. Zattoo channels.
 * Timers can be set from TV / Radio EPG, One-click-setup from epg (Quick Timer)
 * Different schedule modes: once, everyday, Mon-Fri, Fri-Sat, Sat-Sun, Sun-Thu, Mon-Thu, specific weekday and many more
 * Date change is supported, e.g. from 23:30 (p.m.) until 1:30 (a.m.)
 * Shuffle, repeat, 2 end modes, i.e. duration or specific time
-* Actions related to media: start media and stop at end, just start media, start media at end, stop media immediately, stop media at end, powerdown system
+* Actions related to media: start media and stop at end, just start media, start media at end, stop media immediately, stop media at end, power down system
 * Linear fading in timer period: fade-in, fade-out, no fading. Min and max volume can be set for each timer
 * Custom label for timer
-* After KODI startup timers, that are in period, start retroactivly although KODI was not running at start time. Fading volume is calculated correctly.
-* Feature in order to prevent that display is turned off if Kodi idles but is not in fullscreen mode
-* MS Windows only: Feature in order to prevent that Windows displays lock screen if Kodi idles
+* After KODI startup timers, that are in period, start retroactively although KODI was not running at start time. Fading volume is calculated correctly.
+* Feature in order to prevent that display is turned off if KODI idles but is not in full screen mode
+* MS Windows only: Feature in order to prevent that Windows displays lock screen if KODI idles
 
 <img src="script.timers/resources/assets/screenshot_01.png?raw=true">
 
@@ -39,6 +39,11 @@ The result is a powerful timer addon.
 <img src="script.timers/resources/assets/screenshot_09.png?raw=true">
 
 ## Changelog
+v3.5.0 (2023-02-07)
+- New feature: priority of timers and competitive behavior
+- New feature: System action to put playing device on standby via a CEC peripheral
+- Fixed issue so that favorites can be scheduled again
+
 v3.4.0 (2023-01-10)
 - New feature: Media action in order to pause audio or video, feature request #21
 - Refactoring: moved state to timer object
@@ -63,12 +68,12 @@ v3.2.0 (2022-08-27)
 - Set adequate label for playing items instead of internal path
 - Added global configurable offset in order to perform timers ahead of time or later in time
 - Changed context menu 'timers' for EPG
-- Changed resume behaviour if there are two parallel ending timers so that non-resuming timer wins and stops media
+- Changed resume behavior if there are two parallel ending timers so that non-resuming timer wins and stops media
 - Added dialog in order to abort system action
 - Added help texts for all settings
 
 v3.1.0 (2022-05-26)
-- Added feature in order to schedule slideshows, program/script addons and favourites
+- Added feature in order to schedule slideshows, program/script addons and favorites
 - Free selection of weekdays
 - Added feature for shuffling playlists
 - Improved resuming, e.g. in case of media that is shorter than timer
@@ -77,7 +82,7 @@ v3.1.0 (2022-05-26)
 
 v3.0.0 (2022-04-12)
 - Support folders and playlists for scheduling, (feature request https://github.com/Heckie75/kodi-addon-timers/issues/7)
-- Separated configuration of media and system actions, e.g. shutdown Kodi
+- Separated configuration of media and system actions, e.g. shutdown KODI
 - Enable resuming media that has been stopped after timer has finished
 - Enable repeating media and playlists
 - Refactoring (rewrite of scheduler)
@@ -86,10 +91,10 @@ v2.1.2 (2022-02-09)
 - Device wakeup (Issue #6): Explicitly activate CEC Source before player starts
 
 v2.1.1 (2022-01-29)
-- Improved behaviour after update addon. No need to restart Kodi anymore after update
-- Improved prevention lock screen, no restart of Kodi required anymore after setting has changed
-- Refactoring: Usage of modern Kodi API (read and write settings)
-- Added timer actions, i.e. quit Kodi, suspend system, hibernate system, shutdown system
+- Improved behavior after update addon. No need to restart KODI anymore after update
+- Improved prevention lock screen, no restart of KODI required anymore after setting has changed
+- Refactoring: Usage of modern KODI API (read and write settings)
+- Added timer actions, i.e. quit KODI, suspend system, hibernate system, shutdown system
 - Minor bugfixes, e.g. displayed wrong timer no. in some dialogs
 
 v2.1.0 (2021-11-20):
@@ -97,7 +102,7 @@ v2.1.0 (2021-11-20):
 - One-click-setup from epg (Quick Timer)
 - Improved procedure of update state after one-time-timers have run out or settings have been changed
 - Added 5 more timer slots
-- Added feature in order to prevent that display is turned off if Kodi idles but is not in fullscreen mode
+- Added feature in order to prevent that display is turned off if KODI idles but is not in full screen mode
 - Migrated to new XML settings format
 - Major refactoring, better structured code
 
@@ -115,380 +120,5 @@ v2.0.1 (2021-09-12)
 - Bugfix: actions in settings dialog don't work, i.e. 'reset volume' and 'play now'
 
 v2.0.0 (2021-07-18)
-- Migration to Kodi 19 (Matrix)
+- Migration to KODI 19 (Matrix)
 - Total refactoring of earlier version
-
-
-## Overview of supported timer scenarios
-### TC 1. Single timer
-#### TC 1.1. Single timer w/ resume but w/o former media
-```
-Timer 1           |----+---+---+----R                       (tested w/ PVR and Playlist)
-
-t       |---------|-------T1--------|---------------->
-        t0        t1       t2       t3       t4
-Player            play              stop
-```
-
-Tested:
-- [x] v2.2.0 pre19
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and playlists and non-weekly timer</sup>
-
-#### TC 1.2. Single timer w/ resume and w/ former media
-
-```
-Media 1 |---+---+-|                 |----+---+---+---->     (tested w/ PVR and Playlist)
-Timer 1           |-----+----+------R
-
-t       |----M1---|-------T1--------|--------M1------->     (tested w/ PVR and Playlist)
-        t0        t1       t2       t3       t4
-Player            play              resume
-```
-
-Tested:
-- [x] v2.2.0 pre19
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and playlists and non-weekly timer</sup>
-
-#### TC 1.3. Single timer w/o resume and w/ former media
-
-```
-Media 1 |---------|                                         (tested w/ PVR and Playlist)
-Timer 1           |-----------------X                       (tested w/ PVR and Playlist)
-
-t       |----M1---|-------T1--------|---------------->
-        t0        t1       t2       t3       t4
-Player            play              stop
-```
-
-Tested:
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and playlists and non-weekly timer</sup>
-
-### TC 2. Overlapping timers
-#### TC 2.1. Overlapping timers w/ resume but w/o former media
-```
-Timer 1           |------------------R
-Timer 2                      |-----------------R
-
-t       |---------|----T1----|-------T2--------|----->
-        t0        t1    t2   t3  t4  t5   t6   t7   t8
-Player            play       play              stop
-```
-
-Tested:
-- [x] v2.2.0 pre19
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and playlists and non-weekly timer</sup>
-
-#### TC 2.2. Overlapping timers w/ resume and w/ former media
-```
-Media 1 |---------|                            |---------------->
-Timer 1           |------------------R
-Timer 2                      |-----------------R
-
-t       |----M1---|----T1----|-------T2--------|-------M1-------->
-        t0        t1    t2   t3  t4  t5   t6   t7   t8
-Player            play       play              resume
-```
-
-Tested:
-- [x] v2.2.0 pre19
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-#### TC 2.3.  Overlapping timers w/o resume and w/ former media
-
-##### TC 2.3.1. T1 and T2 are no resumers
-```
-Media 1 |---------|
-Timer 1           |------------------X
-Timer 2                      |-----------------X
-
-t       |----M1---|----T1----|-------T2--------|---------------->
-        t0        t1    t2   t3  t4  t5   t6   t7   t8
-Player            play       play              stop
-```
-
-Tested:
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-##### TC 2.3.2. Only T1 is no resumer
-```
-Media 1 |---------|
-Timer 1           |------------------X
-Timer 2                      |-----------------R
-
-t       |----M1---|----T1----|-------T2--------|---------------->
-        t0        t1    t2   t3  t4  t5   t6   t7   t8
-
-Player            play       play              stop
-```
-
-Tested:
-- [x] v2.2.0 pre20
-- [ ] v2.2.0 pre21 - T2 resumes T1
-- [x] v2.2.0 pre22 - Unit tests OK, manual test OK
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-##### TC 2.3.3. Only T2 is no resumer
-```
-Media 1 |---------|
-Timer 1           |------------------R
-Timer 2                      |-----------------X
-
-t       |----M1---|----T1----|-------T2--------|---------------->
-        t0        t1    t2   t3  t4  t5   t6   t7   t8
-Player            play       play              stop
-```
-
-Tested:
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-## TC 3. Chained timers
-#### TC 3.1. Chained timers w/ resume but w/o former media
-```
-Timer 1           |----------R
-Timer 2                      |-----------------R
-
-t       |---------|----T1----|-------T2--------|--------->
-        t0        t1   t2    t3      t4        t5      t6
-Player            play       play              stop
-```
-
-Tested:
-- [x] v2.2.0 pre19
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-#### TC 3.2. Chained timers w/ resume and w/ former media
-```
-Media 1 |---------|                            |---------------->
-Timer 1           |----------R
-Timer 2                      |-----------------R
-
-t       |----M1---|----T1----|-------T2--------|-------M1-------->
-        t0        t1   t2    t3      t4        t5      t6
-Player            play       play              resume
-```
-
-Tested:
-- [x] v2.2.0 pre19
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-
-#### TC 3.3. Chained timers timers w/o resume and w/ former media
-##### TC 3.3.1. T1 and T2 are no resumers
-```
-Media 1 |---------|
-Timer 1           |----------X
-Timer 2                      |-----------------X
-
-t       |----M1---|----T1----|-------T2--------|--------------->
-        t0        t1   t2    t3      t4        t5      t6
-Player            play       play              stop
-```
-
-Tested:
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-##### TC 3.3.2. Only T1 is no resumer
-```
-Media 1 |---------|
-Timer 1           |----------X
-Timer 2                      |-----------------R
-
-t       |----M1---|----T1----|-------T2--------|--------------->
-        t0        t1   t2    t3      t4        t5      t6
-Player            play       play              stop
-```
-
-Tested:
-- [x] v2.2.0 pre20
-- [ ] v2.2.0 pre21 - ident. 2.3.2: T2 resumes T1
-- [x] v2.2.0 pre22 - Unit tests OK, manual test OK
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-##### TC 3.3.3. Only T2 is no resumer
-```
-Media 1 |---------|
-Timer 1           |----------R
-Timer 2                      |-----------------X
-        t0        t1   t2    t3      t4        t5      t6
-t       |----M1---|----T1----|-------T2--------|--------------->
-Player            play       play              stop
-```
-
-Tested:
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-## TC 4. Nested timers
-### TC 4.1. Nested timer w/ resume but w/o former media
-```
-Timer 1           |-------------------------R
-Timer 2                  |------R
-
-t       |---------|--T1--|--T2--|---T1------|---------->
-        t0        t1 t2  t3 t4  t5   t6     t7   t8
-Player            play   play   resume
-```
-
-Tested:
-- [x] v2.2.0 pre19
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-### TC 4.2. Nested timer w/ resume and w/ former media
-```
-Media 1 |---------|                         |---------------->
-Timer 1           |-------------------------R
-Timer 2                  |------R
-
-t       |----M1---|--T1--|--T2--|---T1------|------M1-------->
-        t0        t1 t2  t3 t4  t5   t6     t7   t8
-Player            play   play   resume      resume
-```
-
-Tested:
-- [x] v2.2.0 pre19
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-### TC 4.3. Nested timers w/o resume and w/ former media
-#### TC 4.3.1. T1 and T2 are no resumers
-```
-Media 1 |---------|
-Timer 1           |-------------------------X
-Timer 2                  |------X
-
-t       |----M1---|--T1--|--T2--|-----------|---------------->
-        t0        t1 t2  t3 t4  t5   t6     t7   t8
-Player            play   play   stop
-```
-
-Tested:
-- [x] v2.2.0 pre20
-- [ ] v2.2.0 pre21 - After T2 ends it continues playing T2 (FAIL), after T1 ends it stops (OK)
-- [x] v2.2.0 pre22 - Unit test OK, manual test OK
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-#### TC 4.3.2. Only T1 is no resumer
-```
-Media 1 |---------|
-Timer 1           |-------------------------X
-Timer 2                  |------R
-
-t       |----M1---|--T1--|--T2--|---T1------|---------------->
-        t0        t1 t2  t3 t4  t5   t6     t7   t8
-Player            play   play   resume      stop
-```
-
-Tested:
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-#### TC 4.3.3. Only T2 is no resumer
-```
-Media 1 |---------|
-Timer 1           |-------------------------R
-Timer 2                  |------X
-
-t       |----M1---|--T1--|--T2--|-----------|---------------->
-        t0        t1 t2  t3 t4  t5   t6     t7   t8
-Player            play   play   stop
-```
-
-Tested:
-- [ ] v2.2.0 pre20 -> After T1 ends finally it restarts T2 --> Fix: Changed behaviour, i.e. T2 stops playing
-- [ ] v2.2.0 pre21 - ident. TC 4.3.1 - After T2 ends it continues playing T2 (FAIL), after T1 ends it stops (OK)
-- [x] v2.2.0 pre22 - Unit test OK, manual test ok
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-#### TC 4.3.4. Only T2 is no resumer but w/o former media
-```
-Timer 1           |-------------------------R
-Timer 2                  |------X
-
-t       |----M1---|--T1--|--T2--|-----------|---------------->
-        t0        t1 t2  t3 t4  t5   t6     t7   t8
-Player            play   play   stop
-```
-
-Tested:
-- [ ] v2.2.0 pre20 - ident. TC 4.3.3.
-- [FAIL] v2.2.0 pre21 - ident. TC 4.3.1 - After T2 ends it continues playing T2 (FAIL), after T1 ends it stops (OK)
-- [x] v2.2.0 pre22 - Unit test OK, manual test OK
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-#### TC 4.3.5. Only T1 is no resumer but w/o former media
-```
-Timer 1           |-------------------------X
-Timer 2                  |------R
-
-t       |----M1---|--T1--|--T2--|---T1------|---------------->
-        t0        t1 t2  t3 t4  t5   t6     t7   t8
-Player            play   play   resume      stop
-```
-
-Tested:
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with PVR (no seeking possible) and non-weekly timer</sup>
-
-### TC 4.4. Nested timer w/ playlist and w/ resume and w/ former media
-```
-Media 1 |---------|                         |---------------->   (PVR)
-Timer 1           |--+-----+-----+---+------R                    (Playlist)
-Timer 2                  |------R                                (Single track)
-
-t       |----M1---|--T1--|--T2--|---T1------|------M1-------->
-        t0        t1 t2  t3 t4  t5   t6     t7   t8
-Player            play   play   play+seek   resume
-```
-
-Tested:
-- [x] v2.2.0 pre19
-- [x] v2.2.0 pre20
-- [x] v2.2.0 pre21
-
-<sup>Note: Tested with 372non-weekly timer</sup>

--- a/script.timers/addon.xml
+++ b/script.timers/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.timers" name="Timers" version="3.4.0" provider-name="Heckie">
+<addon id="script.timers" name="Timers" version="3.5.0" provider-name="Heckie">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
   </requires>
@@ -31,24 +31,24 @@
     <description lang="en_GB">A powerful timer addon with the following features
 * Unlimited timer slots. All of them can be quickly set up by using context menu
 * single-click-setup for sleep and doze timers
-* Timers can play any resource that it available in Kodi, e.g. music folders, video files, TV/radio programs, slideshows, ressources from 3rd party plugins, e.g. Zattoo channels.
+* Timers can play any resource that it available in KODI, e.g. music folders, video files, TV/radio programs, slideshows, resources from 3rd party plugins, e.g. Zattoo channels.
 * Timers can be set from TV / Radio EPG, One-click-setup from epg (Quick Timer)
 * Different schedule modes: once, everyday, Mon-Fri, Fri-Sat, Sat-Sun, Sun-Thu, Mon-Thu, specific weekday and many more
 * Date change is supported, e.g. from 23:30 (p.m.) until 1:30 (a.m.)
 * Shuffle, repeat, 2 end modes, i.e. duration or specific time
-* Actions related to media: start media and stop at end, just start media, start media at end, stop media immediately, stop media at end, powerdown system
+* Actions related to media: start media and stop at end, just start media, start media at end, stop media immediately, stop media at end, power down system
 * Linear fading in timer period: fade-in, fade-out, no fading. Min and max volume can be set for each timer
 * Custom label for timer
-* After KODI startup timers, that are in period, start retroactivly although KODI was not running at start time. Fading volume is calculated correctly.
-* Feature in order to prevent that display is turned off if Kodi idles but is not in fullscreen mode
-* MS Windows only: Feature in order to prevent that Windows displays lock screen if Kodi idles
+* After KODI startup timers, that are in period, start retroactively although KODI was not running at start time. Fading volume is calculated correctly.
+* Feature in order to prevent that display is turned off if KODI idles but is not in full screen mode
+* MS Windows only: Feature in order to prevent that Windows displays lock screen if KODI idles
     </description>
     <description lang="de_DE">Timer Addon mit folgenden Funktionen
-* 15 Timer, die eingestellt werden können. Alle Timer können über das Kontextmenü geöffnet werden
-* 2 zusätzliche Timer für "Einschlaf"- und "Schlummer"-Timer mit nur einem Klick 
+* Unbegrenzte Anzahl an Timer, die eingestellt werden können. Alle Timer können über das Kontextmenü geöffnet werden
+* Timer für "Einschlaf"- und "Schlummer"-Timer mit nur einem Klick 
 * Timer können alle Medien starten, die in Kodi sind wie Musik, Video, TV/Radio programme, Diashows, andere Addons, z.B. Zattoo. 
 * Einstellung mit nur einem Klick aus EPG (Quick Timer)
-* Verschiedene Zeitplanungen möglich: einmalig, pro Wochentag, Mo-Fr, Fr-Sa, Sa-So, So-Do, Mo-Do u.v.m.
+* Beliebige Zeitplanungen möglich: einmalig, pro Wochentag, Mo-Fr, Fr-Sa, Sa-So, So-Do, Mo-Do, ...
 * Tageswechsel wird unterstützt, z.B. Timer von 23:30 bis 1:30 am nächsten Tag
 * Dauer kann über Zeitraum oder Zeitpunkt eingestellt werden
 * Aktionen mit Medien: starte Wiedergabe und beende diese nach Ablauf, starte Wiedergabe, starte Wiedergabe bei Ablauf, stoppe Wiedergabe sofort, stoppe Wiedergabe nach Ablauf, fahre System herunter
@@ -65,6 +65,11 @@
     <website>https://github.com/Heckie75/kodi-addon-timers</website>
     <source>https://github.com/Heckie75/kodi-addon-timers</source>
     <news>
+v3.5.0 (2023-02-07)
+- New feature: priority of timers and competitive behavior
+- New feature: System action to put playing device on standby via a CEC peripheral
+- Fixed issue so that favourites can be scheduled again
+
 v3.4.0 (2023-01-10)
 - New feature: Media action in order to pause audio or video, feature request #21
 - Refactoring: moved state to timer object

--- a/script.timers/main.py
+++ b/script.timers/main.py
@@ -1,5 +1,4 @@
 import xbmcaddon
-
 from resources.lib.contextmenu.set_timer import SetTimer
 from resources.lib.player.player import Player
 from resources.lib.player.player_utils import preview, reset_volume

--- a/script.timers/migration.py
+++ b/script.timers/migration.py
@@ -1,7 +1,7 @@
 import xbmc
 import xbmcaddon
-
-from resources.lib.timer import storage
+from resources.lib.timer.concurrency import DEFAULT_PRIO
+from resources.lib.timer.storage import Storage
 from resources.lib.utils.settings_utils import (
     activate_on_settings_changed_events, deactivate_on_settings_changed_events)
 
@@ -189,13 +189,14 @@ def migrate_from_4_to_5(addon: xbmcaddon.Addon) -> int:
         except:
             pass
 
-    storage._save_to_storage(storage=_storage)
+    Storage()._save_to_storage(storage=_storage)
 
     return 5
 
 
 def migrate_from_5_to_6(addon: xbmcaddon.Addon) -> int:
 
+    storage = Storage()
     items = storage._load_from_storage()
     for item in items:
         item["start_offset"] = 0
@@ -205,6 +206,18 @@ def migrate_from_5_to_6(addon: xbmcaddon.Addon) -> int:
     storage._save_to_storage(items)
 
     return 6
+
+
+def migrate_from_6_to_7(addon: xbmcaddon.Addon) -> int:
+
+    storage = Storage()
+    items = storage._load_from_storage()
+    for item in items:
+        item["priority"] = DEFAULT_PRIO
+
+    storage._save_to_storage(items)
+
+    return 7
 
 
 def migrate() -> None:
@@ -229,6 +242,9 @@ def migrate() -> None:
 
     if settingsVersion == 5:
         settingsVersion = migrate_from_5_to_6(addon)
+
+    if settingsVersion == 6:
+        settingsVersion = migrate_from_6_to_7(addon)
 
     addon.setSettingInt("settingsVersion", settingsVersion)
 

--- a/script.timers/resources/language/resource.language.de_de/strings.po
+++ b/script.timers/resources/language/resource.language.de_de/strings.po
@@ -65,9 +65,17 @@ msgctxt "#32027"
 msgid "Timers"
 msgstr "Timers"
 
+msgctxt "#32028"
+msgid "Priority"
+msgstr "Priorität"
+
 msgctxt "#32029"
 msgid "Timer deleted"
 msgstr "Timer gelöscht"
+
+msgctxt "#32030"
+msgid "Presets"
+msgstr "Voreinstellungen"
 
 msgctxt "#32032"
 msgid "Prevent lock screen"
@@ -108,6 +116,18 @@ msgstr "um"
 msgctxt "#32042"
 msgid "from"
 msgstr "von"
+
+msgctxt "#32050"
+msgid "This timer interrupts other timers"
+msgstr "Dieser Timer unterbricht andere Timer"
+
+msgctxt "#32051"
+msgid "Other timers interrupt this timer"
+msgstr "Andere Timer unterbrechen diesen Timer"
+
+msgctxt "#32052"
+msgid "Is %s more important?"
+msgstr "Ist %s wichtiger?"
 
 msgctxt "#32060"
 msgid "Schedule"
@@ -221,13 +241,17 @@ msgctxt "#32090"
 msgid "Volume"
 msgstr "Lautstärke"
 
+msgctxt "#32091"
+msgid "Fading"
+msgstr "Ein-/Ausblenden"
+
 msgctxt "#32092"
 msgid "Default volume"
 msgstr "Voreingestellte Lautstärke"
 
-msgctxt "#32091"
-msgid "Fading"
-msgstr "Ein-/Ausblenden"
+msgctxt "#32093"
+msgid "Standby TV via CEC"
+msgstr "Standby TV via CEC"
 
 msgctxt "#32095"
 msgid "Low volume"
@@ -473,6 +497,22 @@ msgctxt "#32171"
 msgid "Offset for timers in seconds"
 msgstr "Versatz für Timer in Sekunden"
 
+msgctxt "#32180"
+msgid "Presets for epg quick timer"
+msgstr "Voreinstellungen für EPG Quicktimer"
+
+msgctxt "#32181"
+msgid "earliest timer"
+msgstr "frühester Timer"
+
+msgctxt "#32182"
+msgid "latest added"
+msgstr "zuletzt hinzugefügt"
+
+msgctxt "#32183"
+msgid "always ask"
+msgstr "jedes mal fragen"
+
 msgctxt "#32200"
 msgid "Monday"
 msgstr "Montag"
@@ -637,6 +677,14 @@ msgctxt "#32335"
 msgid "Enter the duration after the timer ends."
 msgstr "Gebe die Dauer ein, nach der der Timer endet."
 
+msgctxt "#32336"
+msgid "Set value if this timer is more important than other. Higher value means more important. Values higher than 10 always win against newbies."
+msgstr "Setze einen Wert wenn dieser Timer wichtiger ist als andere. Je höher der Wert desto wichtiger. Werte größer 10 gewinnen immer gegen neue Timer."
+
+msgctxt "#32337"
+msgid "This is a high priority timer which overrule new timers."
+msgstr "Dies ist ein Timer mit hoher Priorität, der neue Timer übersteuern kann."
+
 msgctxt "#32340"
 msgid "Select the media action of the timer. Note that you must add a media to the timer by utilizing the context menu first."
 msgstr "Wähle die Mediaaktion aus, die der Timer ausführen soll. Beachte, dass Du zuerst ein Mediaelement über das Kontextmenu dem Timer hinzufügen musst."
@@ -700,3 +748,7 @@ msgstr "Verhindere Sperrbildschirm von MS Windows während Kodi ausgeführt wird
 msgctxt "#32385"
 msgid "Optionally you can set an offset in seconds."
 msgstr "Optional kann ein Versatz in Sekunden angegeben werden."
+
+msgctxt "#32386"
+msgid "Determine the strategy for priority of new quicktimers."
+msgstr "Bestimme die Strategie für die Priorität neuer Quicktimer."

--- a/script.timers/resources/language/resource.language.en_gb/strings.po
+++ b/script.timers/resources/language/resource.language.en_gb/strings.po
@@ -65,8 +65,16 @@ msgctxt "#32027"
 msgid "Timers"
 msgstr ""
 
+msgctxt "#32028"
+msgid "Priority"
+msgstr ""
+
 msgctxt "#32029"
 msgid "Timer deleted"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Presets"
 msgstr ""
 
 msgctxt "#32032"
@@ -107,6 +115,18 @@ msgstr ""
 
 msgctxt "#32042"
 msgid "from"
+msgstr ""
+
+msgctxt "#32050"
+msgid "This timer interrupts other timers"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Other timers interrupt this timer"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Is %s more important?"
 msgstr ""
 
 msgctxt "#32060"
@@ -221,12 +241,16 @@ msgctxt "#32090"
 msgid "Volume"
 msgstr ""
 
+msgctxt "#32091"
+msgid "Fading"
+msgstr ""
+
 msgctxt "#32092"
 msgid "Default volume"
 msgstr ""
 
-msgctxt "#32091"
-msgid "Fading"
+msgctxt "#32093"
+msgid "Standby TV via CEC"
 msgstr ""
 
 msgctxt "#32095"
@@ -473,6 +497,22 @@ msgctxt "#32171"
 msgid "Offset for timers in seconds"
 msgstr ""
 
+msgctxt "#32180"
+msgid "Presets for epg quick timer"
+msgstr ""
+
+msgctxt "#32181"
+msgid "earliest timer"
+msgstr ""
+
+msgctxt "#32182"
+msgid "latest added"
+msgstr ""
+
+msgctxt "#32183"
+msgid "always ask"
+msgstr ""
+
 msgctxt "#32200"
 msgid "Monday"
 msgstr ""
@@ -637,6 +677,14 @@ msgctxt "#32335"
 msgid "Enter the duration after the timer ends."
 msgstr ""
 
+msgctxt "#32336"
+msgid "Set value if this timer is more important than other. Higher value means more important. Values higher than 10 always win against newbies."
+msgstr ""
+
+msgctxt "#32337"
+msgid "This is a high priority timer which overrule new timers."
+msgstr ""
+
 msgctxt "#32340"
 msgid "Select the media action of the timer. Note that you must add a media to the timer by utilizing the context menu first."
 msgstr ""
@@ -699,4 +747,8 @@ msgstr ""
 
 msgctxt "#32385"
 msgid "Optionally you can set an offset in seconds."
+msgstr ""
+
+msgctxt "#32386"
+msgid "Determine the strategy for priority of new quicktimers."
 msgstr ""

--- a/script.timers/resources/lib/contextmenu/abstract_set_timer.py
+++ b/script.timers/resources/lib/contextmenu/abstract_set_timer.py
@@ -6,17 +6,15 @@ import xbmcaddon
 import xbmcgui
 from resources.lib.contextmenu import pvr_utils
 from resources.lib.player.mediatype import VIDEO
-from resources.lib.timer import storage
+from resources.lib.timer.concurrency import determine_overlappings
+from resources.lib.timer.storage import Storage
 from resources.lib.timer.timer import (END_TYPE_DURATION, END_TYPE_NO,
                                        FADE_OFF, MEDIA_ACTION_START_STOP,
                                        SYSTEM_ACTION_NONE, Timer)
 from resources.lib.utils import datetime_utils, vfs_utils
-from resources.lib.utils.settings_utils import trigger_settings_changed_event
-
-CONFIRM_ESCAPE = -1
-CONFIRM_NO = 0
-CONFIRM_YES = 1
-CONFIRM_EDIT = 2
+from resources.lib.utils.settings_utils import (CONFIRM_CUSTOM, CONFIRM_ESCAPE,
+                                                CONFIRM_NO, CONFIRM_YES,
+                                                trigger_settings_changed_event)
 
 
 class AbstractSetTimer:
@@ -24,6 +22,7 @@ class AbstractSetTimer:
     def __init__(self, label: str, path: str, timerid=-1) -> None:
 
         self.addon = xbmcaddon.Addon()
+        self.storage = Storage()
 
         if not self.is_supported(label, path):
             yes = xbmcgui.Dialog().yesno(heading=self.addon.getLocalizedString(
@@ -96,6 +95,15 @@ class AbstractSetTimer:
             timer.vol_min = vol_min
             timer.vol_max = vol_max
 
+        timer.init()
+        overlappings = determine_overlappings(
+            timer, self.storage.load_timers_from_storage())
+        if overlappings:
+            answer = self.handle_overlapping_timers(
+                timer, overlapping_timers=overlappings)
+            if answer in [CONFIRM_ESCAPE, CONFIRM_CUSTOM]:
+                return
+
         confirm = self.confirm(timer)
         if confirm in [CONFIRM_ESCAPE, CONFIRM_NO]:
             return
@@ -128,7 +136,7 @@ class AbstractSetTimer:
 
     def ask_timer(self, timerid: int) -> int:
 
-        return storage.get_next_id()
+        return self.storage.get_next_id()
 
     def ask_days(self, label: str, path: str, is_epg: bool, timer: Timer) -> 'list[int]':
 
@@ -162,6 +170,13 @@ class AbstractSetTimer:
 
         return FADE_OFF, timer.vol_min, timer.vol_max
 
+    def handle_overlapping_timers(self, timer: Timer, overlapping_timers: 'list[Timer]') -> int:
+
+        timer.priority = max(overlapping_timers,
+                             key=lambda t: t.priority).priority + 1
+
+        return CONFIRM_YES
+
     def confirm(self, timer: Timer) -> int:
 
         return CONFIRM_YES
@@ -169,18 +184,14 @@ class AbstractSetTimer:
     def post_apply(self, timer: Timer, confirm: int) -> None:
 
         if confirm == CONFIRM_YES:
-            lines = list()
-            lines.append(timer.periods_to_human_readable())
-            if timer.system_action:
-                lines.append("%s: %s" % (self.addon.getLocalizedString(32081),
-                                         self.addon.getLocalizedString(32081 + timer.system_action)))
-
+            msg = ("$H\n%s: $P" % self.addon.getLocalizedString(
+                32081)) if timer.system_action else "$H"
             xbmcgui.Dialog().notification(heading=timer.label,
-                                          message="\n".join(lines), icon=vfs_utils.get_asset_path("icon.png"))
+                                          message=timer.format(msg), icon=vfs_utils.get_asset_path("icon.png"))
 
     def _get_timer_preselection(self, timerid: int, label: str, path: str) -> 'tuple[Timer,bool]':
 
-        timer = storage.load_timer_from_storage(timerid)
+        timer = self.storage.load_timer_from_storage(timerid)
         if not timer:
             timer = Timer(timerid)
             timer.vol_min = self.addon.getSettingInt("vol_min_default")
@@ -239,5 +250,5 @@ class AbstractSetTimer:
 
     def apply(self, timer: Timer) -> None:
 
-        storage.save_timer(timer=timer)
+        self.storage.save_timer(timer=timer)
         trigger_settings_changed_event()

--- a/script.timers/resources/lib/player/player_utils.py
+++ b/script.timers/resources/lib/player/player_utils.py
@@ -2,7 +2,7 @@ import xbmc
 import xbmcaddon
 import xbmcgui
 from resources.lib.player.mediatype import AUDIO, PICTURE, TYPES, VIDEO
-from resources.lib.timer import storage
+from resources.lib.timer.storage import Storage
 from resources.lib.utils.jsonrpc_utils import json_rpc
 from resources.lib.utils.vfs_utils import (build_playlist, convert_to_playlist,
                                            get_asset_path, get_files_and_type,
@@ -36,13 +36,13 @@ class State():
                                                                                                                        self.repeat,
                                                                                                                        self.shuffled,
                                                                                                                        self.speed)
-    
+
 
 def preview(addon: xbmcaddon.Addon, timerid: int, player: 'xbmc.Player') -> None:
 
-    timer = storage.load_timer_from_storage(timerid)
+    timer = Storage().load_timer_from_storage(timerid)
 
-    if timer._is_playing_media_timer():
+    if timer.is_playing_media_timer():
 
         xbmcgui.Dialog().notification(addon.getLocalizedString(32027), timer.label,
                                       icon=get_asset_path("icon.png"))

--- a/script.timers/resources/lib/test/mockstorage.py
+++ b/script.timers/resources/lib/test/mockstorage.py
@@ -1,0 +1,22 @@
+from resources.lib.timer.storage import Storage
+
+
+class MockStorage(Storage):
+
+    def __init__(self, data: 'list[dict]' = list()) -> None:
+        super().__init__()
+
+        self._data = data
+
+    def release_lock(self) -> None:
+
+        self.lock = None
+
+    def _load_from_storage(self) -> 'list[dict]':
+
+        return self._data
+
+    def _save_to_storage(self, storage: 'list[dict]') -> None:
+
+        storage.sort(key=lambda item: item["id"])
+        self._data = storage

--- a/script.timers/resources/lib/timer/concurrency.py
+++ b/script.timers/resources/lib/timer/concurrency.py
@@ -1,0 +1,164 @@
+import xbmcaddon
+import xbmcgui
+from resources.lib.player.player_utils import get_types_replaced_by_type
+from resources.lib.timer.period import Period
+from resources.lib.timer.timer import (MEDIA_ACTION_START,
+                                       MEDIA_ACTION_START_AT_END,
+                                       MEDIA_ACTION_START_STOP,
+                                       MEDIA_ACTION_STOP,
+                                       MEDIA_ACTION_STOP_AT_END,
+                                       MEDIA_ACTION_STOP_START, Timer)
+from resources.lib.utils import datetime_utils
+from resources.lib.utils.settings_utils import (CONFIRM_CUSTOM, CONFIRM_NO,
+                                                CONFIRM_YES)
+
+MIN_PRIO = -15
+MAX_PRIO = 15
+HIGH_PRIO_THRESHOLD = 10
+DEFAULT_PRIO = 0
+
+
+def get_next_lower_prio(timers: 'list[Timer]') -> int:
+
+    _min = min(timers, key=lambda t: t.priority).priority - 1
+    return max(_min, MIN_PRIO)
+
+
+def get_next_higher_prio(timers: 'list[Timer]') -> int:
+
+    _max = max(timers, key=lambda t: t.priority if t.priority <=
+               HIGH_PRIO_THRESHOLD else DEFAULT_PRIO).priority
+    return _max + 1 if _max < HIGH_PRIO_THRESHOLD - 1 else _max
+
+
+def determine_overlappings(timer: Timer, timers: 'list[Timer]') -> 'list[Timer]':
+
+    def _disturbs(types: 'list[str]', type2: str, media_action1: int, media_action2: int, period1: Period, period2: Period) -> bool:
+
+        if media_action1 == MEDIA_ACTION_START_STOP:
+            td_play_media1 = period1.start
+            td_stop_media1 = period1.end
+            replace = type2 in types
+
+        elif media_action1 == MEDIA_ACTION_START:
+            td_play_media1 = period1.start
+            td_stop_media1 = None
+            replace = type2 in types
+
+        elif media_action1 == MEDIA_ACTION_START_AT_END:
+            td_play_media1 = period1.end
+            td_stop_media1 = None
+            replace = type2 in types
+
+        elif media_action1 == MEDIA_ACTION_STOP_START:
+            td_play_media1 = period1.end
+            td_stop_media1 = period1.start
+            replace = type2 in types
+
+        elif media_action1 == MEDIA_ACTION_STOP:
+            td_play_media1 = None
+            td_stop_media1 = period1.start
+            replace = True
+
+        elif media_action1 == MEDIA_ACTION_STOP_AT_END:
+            td_play_media1 = None
+            td_stop_media1 = period1.end
+            replace = True
+
+        else:
+            return False
+
+        if not replace:
+            return False
+
+        if media_action2 == MEDIA_ACTION_START_STOP:
+
+            if td_play_media1:
+                s, e, hit = period2.hit(td_play_media1)
+                if s and e and hit:
+                    return True
+
+            if td_stop_media1:
+                s, e, hit = period2.hit(td_stop_media1)
+                if s and e and hit:
+                    return True
+
+            return False
+
+        elif media_action2 == MEDIA_ACTION_STOP_START:
+
+            if td_play_media1:
+                s, e, hit = period2.hit(td_play_media1)
+                return s and e and hit
+
+        return False
+
+    timer_replace_types = get_types_replaced_by_type(timer.media_type)
+
+    overlapping_timers = list()
+    for t in timers:
+
+        if t.id == timer.id:
+            continue
+
+        t_replace_types = get_types_replaced_by_type(t.media_type)
+
+        overlapping_periods: 'list[Period]' = list()
+        for p in t.periods:
+
+            for n in timer.periods:
+
+                if _disturbs(timer_replace_types, t.media_type, timer.media_action, t.media_action, n, p) or _disturbs(t_replace_types, timer.media_type, t.media_action, timer.media_action, p, n):
+                    overlapping_periods.append(p)
+
+        if overlapping_periods:
+            days = [
+                datetime_utils.WEEKLY] if datetime_utils.WEEKLY in t.days else list()
+            days.extend([p.start.days for p in overlapping_periods])
+            t.days = days
+            t.periods = overlapping_periods
+            overlapping_timers.append(t)
+
+    return overlapping_timers
+
+
+def ask_overlapping_timers(timer: Timer, overlapping_timers: 'list[Timer]') -> int:
+
+    addon = xbmcaddon.Addon()
+
+    earlier_timers = [
+        t for t in overlapping_timers if t.periods[0].start < timer.periods[0].start]
+
+    lines = list()
+    for t in overlapping_timers:
+        lines.append(t.format("$L ($H)", 50, 12))
+    lines.append("\n" + addon.getLocalizedString(32052) %
+                 timer.format("$L ($T)", 50, 12))
+
+    if earlier_timers:
+
+        answer = xbmcgui.Dialog().yesnocustom(heading=addon.getLocalizedString(
+            32050), message="\n".join(lines), customlabel=addon.getLocalizedString(32022))
+
+        if answer == CONFIRM_NO:
+            timer.priority = get_next_lower_prio(overlapping_timers)
+            return CONFIRM_YES
+
+        elif answer == CONFIRM_YES:
+            timer.priority = max(overlapping_timers,
+                                 key=lambda t: t.priority).priority
+            return CONFIRM_YES
+
+    else:
+        answer = xbmcgui.Dialog().yesnocustom(heading=addon.getLocalizedString(
+            32051), message="\n".join(lines), customlabel=addon.getLocalizedString(32022))
+
+        if answer == CONFIRM_YES:
+            timer.priority = get_next_higher_prio(overlapping_timers)
+            return CONFIRM_YES
+
+        elif answer == CONFIRM_NO:
+            timer.priority = DEFAULT_PRIO
+            return CONFIRM_YES
+
+    return CONFIRM_CUSTOM

--- a/script.timers/resources/lib/timer/period.py
+++ b/script.timers/resources/lib/timer/period.py
@@ -8,5 +8,37 @@ class Period:
         self.start: timedelta = start
         self.end: timedelta = end
 
+    def _compare(self, period_start: timedelta, period_end: timedelta) -> 'tuple[timedelta,timedelta,timedelta]':
+
+        self_start = self.start
+        self_end = self.end
+        week = timedelta(days=7)
+
+        if self_start > self_end and period_start <= period_end:
+            self_end += week
+            if period_end < self_start:
+                period_start += week
+                period_end += week
+
+        elif self_start <= self_end and period_start > period_end:
+            period_end += week
+            if self_end < period_start:
+                self_start += week
+                self_end += week
+
+        max_start = max(self_start, period_start)
+        min_end = min(self_end, period_end)
+
+        return self_start - period_start, self_end - period_end, min_end - max_start if max_start <= min_end else None
+
+    def compare(self, period: 'Period') -> 'tuple[timedelta,timedelta,timedelta]':
+
+        return self._compare(period.start, period.end)
+
+    def hit(self, timestamp: timedelta) -> 'tuple[timedelta,timedelta, bool]':
+
+        s, e, l = self._compare(timestamp, timestamp)
+        return s, e, l is not None
+
     def __str__(self) -> str:
         return "Period[start=%s, end=%s]" % (self.start, self.end)

--- a/script.timers/resources/lib/timer/scheduleraction.py
+++ b/script.timers/resources/lib/timer/scheduleraction.py
@@ -7,23 +7,28 @@ from resources.lib.player.mediatype import AUDIO, PICTURE, TYPES, VIDEO
 from resources.lib.player.player import Player
 from resources.lib.player.player_utils import (get_types_replaced_by_type,
                                                run_addon)
-from resources.lib.timer import storage
+from resources.lib.timer.storage import Storage
 from resources.lib.timer.timer import (END_TYPE_NO, FADE_IN_FROM_MIN,
                                        FADE_OUT_FROM_CURRENT, STATE_ENDING,
                                        STATE_RUNNING, STATE_STARTING,
-                                       STATE_WAITING, SYSTEM_ACTION_HIBERNATE,
-                                       SYSTEM_ACTION_POWEROFF, SYSTEM_ACTION_QUIT_KODI,
-                                       SYSTEM_ACTION_SHUTDOWN_KODI, SYSTEM_ACTION_STANDBY,
-                                       TIMER_WEEKLY, Timer)
+                                       STATE_WAITING,
+                                       SYSTEM_ACTION_CEC_STANDBY,
+                                       SYSTEM_ACTION_HIBERNATE,
+                                       SYSTEM_ACTION_POWEROFF,
+                                       SYSTEM_ACTION_QUIT_KODI,
+                                       SYSTEM_ACTION_SHUTDOWN_KODI,
+                                       SYSTEM_ACTION_STANDBY, TIMER_WEEKLY,
+                                       Timer)
 from resources.lib.utils.datetime_utils import DateTimeDelta, abs_time_diff
 from resources.lib.utils.vfs_utils import get_asset_path
 
 
 class SchedulerAction:
 
-    def __init__(self, player: Player) -> None:
+    def __init__(self, player: Player, storage: Storage) -> None:
 
         self._player: Player = player
+        self.storage = storage
 
         self.upcoming_event: datetime = None
         self.upcoming_timer: Timer = None
@@ -60,6 +65,7 @@ class SchedulerAction:
             if timer.is_stop_at_end_timer():
                 _tts = self.timerToStopSlideshow if timer.media_type == PICTURE else self.timerToStopAV
                 if (not _tts
+                        or _tts.priority < timer.priority
                         or _tts.is_resuming_timer() and timer.current_period.start >= _tts.current_period.start):
                     self._setTimerToStopAny(timer)
 
@@ -96,6 +102,13 @@ class SchedulerAction:
 
         def _handleNestedStoppingTimer(timerToStop: Timer) -> None:
 
+            def _reset_stop():
+                if _stopMediatype in [AUDIO, VIDEO]:
+                    self.timerToStopAV = None
+
+                elif _stopMediatype == PICTURE:
+                    self.timerToStopSlideshow = None
+
             if timerToStop:
                 _stopMediatype = timerToStop.media_type
                 _types_replaced_by_type = get_types_replaced_by_type(
@@ -103,23 +116,25 @@ class SchedulerAction:
                 for overlappingTimer in self._runningTimers:
                     if (overlappingTimer.media_type in _types_replaced_by_type
                             and overlappingTimer.is_play_at_start_timer() and overlappingTimer.is_stop_at_end_timer()
-                            and timerToStop.current_period.start < overlappingTimer.current_period.start
+                            and timerToStop.current_period.start <= overlappingTimer.current_period.start
                             and timerToStop.current_period.end < overlappingTimer.current_period.end):
 
                         self._forceResumeResetTypes.extend(
                             _types_replaced_by_type if not timerToStop.is_resuming_timer() else list())
 
-                        if _stopMediatype in [AUDIO, VIDEO]:
-                            self.timerToStopAV = None
+                        if overlappingTimer.priority < timerToStop.priority and overlappingTimer.media_type in _types_replaced_by_type:
+                            self._beginningTimers.append(overlappingTimer)
 
-                        elif _stopMediatype == PICTURE:
-                            self.timerToStopSlideshow = None
+                        _reset_stop()
 
-                        return
+                enclosingTimers = [t for t in self._runningTimers if (t.current_period.start < timerToStop.current_period.start
+                                                                      and t.current_period.end > timerToStop.current_period.end)
+                                   and t.media_type in _stopMediatype]
 
-                if timerToStop.is_resuming_timer():
-                    enclosingTimers = [t for t in self._runningTimers if (t.current_period.start < timerToStop.current_period.start
-                                                                          and t.current_period.end > timerToStop.current_period.end)]
+                if enclosingTimers and not [t for t in enclosingTimers if timerToStop.priority >= t.priority]:
+                    _reset_stop()
+
+                elif timerToStop.is_resuming_timer():
                     self._beginningTimers.extend(enclosingTimers)
 
         def _handleStartingTimers() -> None:
@@ -132,7 +147,10 @@ class SchedulerAction:
                     elif timer.return_vol == None:
                         timer.return_vol = self._player.getVolume()
 
-                if timer.is_play_at_start_timer():
+                higher_prio_runnings = [running for running in self._runningTimers if running.priority > timer.priority
+                                        and running.media_type in get_types_replaced_by_type(timer.media_type)]
+
+                if not higher_prio_runnings and timer.is_play_at_start_timer():
                     self._setTimerToPlayAny(timer)
 
                 elif timer.is_stop_at_start_timer():
@@ -143,7 +161,7 @@ class SchedulerAction:
 
         def _handleSystemAction() -> None:
 
-            if not self.timerWithSystemAction:
+            if not self.timerWithSystemAction or self.timerWithSystemAction.system_action == SYSTEM_ACTION_CEC_STANDBY:
                 return
 
             addon = xbmcaddon.Addon()
@@ -239,10 +257,10 @@ class SchedulerAction:
             self.timersToRunScript.append(timer)
 
         elif timer.media_type == PICTURE:
-            self.timerToPlaySlideshow = timer
+            self.timerToPlaySlideshow = timer if self.timerToPlaySlideshow is None or self.timerToPlaySlideshow.priority < timer.priority else self.timerToPlaySlideshow
 
         else:
-            self.timerToPlayAV = timer
+            self.timerToPlayAV = timer if self.timerToPlayAV is None or self.timerToPlayAV.priority < timer.priority else self.timerToPlayAV
 
     def fade(self, dtd: DateTimeDelta) -> None:
 
@@ -282,7 +300,7 @@ class SchedulerAction:
             elif self.timerToUnpauseAV and self._player.isPaused():
                 self._player.pause()
 
-            for type in self._forceResumeResetTypes:
+            for type in set(self._forceResumeResetTypes):
                 self._player.resetResumeStatus(type)
 
             if not self.timerToPlayAV or self.timerToPlayAV.media_type != VIDEO:
@@ -335,9 +353,9 @@ class SchedulerAction:
                             timer.days.remove(timer.current_period.start.days)
 
                         if not timer.days:
-                            storage.delete_timer(timer.id)
+                            self.storage.delete_timer(timer.id)
                         else:
-                            storage.save_timer(timer=timer)
+                            self.storage.save_timer(timer=timer)
 
             _reset(self._endingTimers)
             if self.timerWithSystemAction:
@@ -367,6 +385,9 @@ class SchedulerAction:
 
             elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_POWEROFF:
                 xbmc.executebuiltin("Powerdown()")
+
+            elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_CEC_STANDBY:
+                xbmc.executebuiltin("CECStandby()")
 
         def _adjustState() -> None:
 

--- a/script.timers/resources/lib/timer/storage.py
+++ b/script.timers/resources/lib/timer/storage.py
@@ -9,214 +9,207 @@ import xbmcvfs
 from resources.lib.timer.timer import STATE_WAITING, Timer
 
 
-def _get_storage_path() -> str:
+class Storage():
 
-    addon = xbmcaddon.Addon()
-    profile_path = xbmcvfs.translatePath(addon.getAddonInfo('profile'))
-    return os.path.join(profile_path, "timers.json")
+    def _get_storage_path(self) -> str:
 
+        addon = xbmcaddon.Addon()
+        profile_path = xbmcvfs.translatePath(addon.getAddonInfo('profile'))
+        return os.path.join(profile_path, "timers.json")
 
-def _aquire_lock() -> str:
+    def _aquire_lock(self) -> str:
 
-    lock_path = "%s.lck" % _get_storage_path()
-    lock = str(int(time.time()))
+        lock_path = "%s.lck" % self._get_storage_path()
+        lock = str(int(time.time()))
 
-    with xbmcvfs.File(lock_path, "w") as file:
-        file.write(lock)
+        with xbmcvfs.File(lock_path, "w") as file:
+            file.write(lock)
 
-    return lock
+        return lock
 
+    def release_lock(self) -> None:
 
-def release_lock() -> None:
+        lock_file = "%s.lck" % self._get_storage_path()
+        if xbmcvfs.exists(lock_file):
+            xbmcvfs.rmdir(lock_file, force=True)
 
-    lock_file = "%s.lck" % _get_storage_path()
-    if xbmcvfs.exists(lock_file):
-        xbmcvfs.rmdir(lock_file, force=True)
+    def _wait_for_unlock(self) -> None:
 
+        lock_path = "%s.lck" % self._get_storage_path()
 
-def _wait_for_unlock() -> None:
+        wait = 5
+        while xbmcvfs.exists(lock_path) and wait > 0:
 
-    lock_path = "%s.lck" % _get_storage_path()
+            xbmc.sleep(100 + int(random.random() * 100))
+            wait -= 1
 
-    wait = 5
-    while xbmcvfs.exists(lock_path) and wait > 0:
+        if wait == 0:
+            xbmc.log("%s is locked. Unlock now with small risk of data loss." %
+                     self._get_storage_path(), xbmc.LOGWARNING)
+            self.release_lock()
 
-        xbmc.sleep(100 + int(random.random() * 100))
-        wait -= 1
+    def _load_from_storage(self) -> 'list[dict]':
 
-    if wait == 0:
-        xbmc.log("%s is locked. Unlock now with small risk of data loss." %
-                 _get_storage_path(), xbmc.LOGWARNING)
-        release_lock()
+        self._wait_for_unlock()
 
+        storage_path = self._get_storage_path()
+        _storage = list()
+        if xbmcvfs.exists(storage_path):
+            with xbmcvfs.File(storage_path, "r") as file:
+                try:
+                    _storage.extend(json.load(file))
+                except:
+                    # this should normally not be a problem, but it fails when running unit tests
+                    xbmc.log("Can't read timers from storage.",
+                             xbmc.LOGWARNING)
 
-def _load_from_storage() -> 'list[dict]':
+        return _storage
 
-    _wait_for_unlock()
+    def _save_to_storage(self, storage: 'list[dict]') -> None:
 
-    storage_path = _get_storage_path()
-    _storage = list()
-    if xbmcvfs.exists(storage_path):
-        with xbmcvfs.File(storage_path, "r") as file:
-            try:
-                _storage.extend(json.load(file))
-            except:
-                # this should normally not be a problem, but it fails when running unit tests
-                xbmc.log("Can't read timers from storage.", xbmc.LOGWARNING)
+        storage.sort(key=lambda item: item["id"])
+        storage_path = self._get_storage_path()
 
-    return _storage
+        self._wait_for_unlock()
+        try:
+            lock = self._aquire_lock()
+            tmp = "%s.%s" % (storage_path, lock)
+            old = "%s.old" % storage_path
+            with xbmcvfs.File(tmp, "w") as file:
+                json.dump(obj=storage, fp=file, indent=2, sort_keys=True)
 
+            if xbmcvfs.exists(old):
+                xbmcvfs.delete(old)
 
-def _save_to_storage(storage: 'list[dict]') -> None:
+            xbmcvfs.rename(storage_path, old)
+            xbmcvfs.rename(tmp, storage_path)
 
-    storage.sort(key=lambda item: item["id"])
-    storage_path = _get_storage_path()
+        finally:
+            self.release_lock()
 
-    _wait_for_unlock()
-    try:
-        lock = _aquire_lock()
-        tmp = "%s.%s" % (storage_path, lock)
-        old = "%s.old" % storage_path
-        with xbmcvfs.File(tmp, "w") as file:
-            json.dump(obj=storage, fp=file, indent=2, sort_keys=True)
+    def load_timers_from_storage(self) -> 'list[Timer]':
 
-        if xbmcvfs.exists(old):
-            xbmcvfs.delete(old)
+        timers = list()
+        storage = self._load_from_storage()
+        for item in storage:
+            timers.append(self._init_timer_from_item(item))
 
-        xbmcvfs.rename(storage_path, old)
-        xbmcvfs.rename(tmp, storage_path)
+        return timers
 
-    finally:
-        release_lock()
+    def load_timer_from_storage(self, id: int) -> Timer:
 
+        storage = self._load_from_storage()
+        for item in storage:
+            if item["id"] == id:
+                return self._init_timer_from_item(item)
 
-def load_timers_from_storage() -> 'list[Timer]':
+        return None
 
-    timers = list()
-    storage = _load_from_storage()
-    for item in storage:
-        timers.append(_init_timer_from_item(item))
+    def _init_timer_from_item(self, item: dict) -> Timer:
 
-    return timers
-
-
-def load_timer_from_storage(id: int) -> Timer:
-
-    storage = _load_from_storage()
-    for item in storage:
-        if item["id"] == id:
-            return _init_timer_from_item(item)
-
-    return None
-
-
-def _init_timer_from_item(item: dict) -> Timer:
-
-    timer = Timer(item["id"])
-    timer.label = item["label"]
-    timer.system_action = item["system_action"]
-    timer.media_action = item["media_action"]
-    timer.fade = item["fade"]
-    timer.vol_min = item["vol_min"]
-    timer.vol_max = item["vol_max"]
-    timer.path = item["path"]
-    timer.media_type = item["media_type"]
-    timer.repeat = item["repeat"]
-    timer.shuffle = item["shuffle"]
-    timer.resume = item["resume"]
-
-    item["days"].sort()
-    timer.days = item["days"]
-
-    timer.start = item["start"]
-    timer.start_offset = item["start_offset"]
-    timer.end_type = item["end_type"]
-    timer.end = item["end"]
-    timer.end_offset = item["end_offset"]
-    timer.duration = item["duration"]
-    timer.duration_offset = item["duration_offset"]
-
-    timer.notify = item["notify"]
-
-    timer.return_vol = None
-    timer.state = STATE_WAITING
-
-    timer.init()
-
-    return timer
-
-
-def _find_item_index(storage: 'list[dict]', id: int) -> int:
-
-    for i, item in enumerate(storage):
-        if item["id"] == id:
-            return i
-
-    return -1
-
-
-def save_timer(timer: Timer) -> None:
-
-    timer.init()
-
-    item = {
-        "days": timer.days,
-        "duration": timer.duration,
-        "duration_offset": timer.duration_offset,
-        "end": timer.end,
-        "end_offset": timer.end_offset,
-        "end_type": timer.end_type,
-        "fade": timer.fade,
-        "id": timer.id,
-        "label": timer.label,
-        "media_action": timer.media_action,
-        "media_type": timer.media_type,
-        "notify": timer.notify,
-        "path": timer.path,
-        "repeat": timer.repeat,
-        "resume": timer.resume,
-        "shuffle": timer.shuffle,
-        "start": timer.start,
-        "start_offset": timer.start_offset,
-        "system_action": timer.system_action,
-        "vol_min": timer.vol_min,
-        "vol_max": timer.vol_max
-    }
-
-    storage = _load_from_storage()
-    idx = _find_item_index(storage, timer.id)
-    if idx == -1:
-        storage.append(item)
-    else:
-        storage[idx] = item
-
-    _save_to_storage(storage)
-
-
-def delete_timer(timer_id: int) -> None:
-
-    storage = _load_from_storage()
-    idx = _find_item_index(storage, timer_id)
-    if idx >= 0:
-        storage.pop(idx)
-        _save_to_storage(storage=storage)
-
-
-def get_scheduled_timers() -> 'list[Timer]':
-
-    timers = load_timers_from_storage()
-    scheduled_timers = list([timer for timer in timers if timer.days])
-    scheduled_timers.sort(key=lambda timer: (timer.days, timer.start,
-                                             timer.media_action, timer.system_action))
-    return scheduled_timers
-
-
-def get_next_id() -> int:
-
-    storage = _load_from_storage()
-
-    next_id = 0
-    if storage:
-        next_id = max(storage, key=lambda item: item["id"])["id"] + 1
-
-    return next_id
+        timer = Timer(item["id"])
+        timer.label = item["label"]
+        timer.system_action = item["system_action"]
+        timer.media_action = item["media_action"]
+        timer.fade = item["fade"]
+        timer.vol_min = item["vol_min"]
+        timer.vol_max = item["vol_max"]
+        timer.path = item["path"]
+        timer.media_type = item["media_type"]
+        timer.repeat = item["repeat"]
+        timer.shuffle = item["shuffle"]
+        timer.resume = item["resume"]
+
+        item["days"].sort()
+        timer.days = item["days"]
+
+        timer.start = item["start"]
+        timer.start_offset = item["start_offset"]
+        timer.end_type = item["end_type"]
+        timer.end = item["end"]
+        timer.end_offset = item["end_offset"]
+        timer.duration = item["duration"]
+        timer.duration_offset = item["duration_offset"]
+
+        timer.priority = item["priority"]
+
+        timer.notify = item["notify"]
+
+        timer.return_vol = None
+        timer.state = STATE_WAITING
+
+        timer.init()
+
+        return timer
+
+    def _find_item_index(self, storage: 'list[dict]', id: int) -> int:
+
+        for i, item in enumerate(storage):
+            if item["id"] == id:
+                return i
+
+        return -1
+
+    def save_timer(self, timer: Timer) -> None:
+
+        timer.init()
+
+        item = {
+            "days": timer.days,
+            "duration": timer.duration,
+            "duration_offset": timer.duration_offset,
+            "end": timer.end,
+            "end_offset": timer.end_offset,
+            "end_type": timer.end_type,
+            "fade": timer.fade,
+            "id": timer.id,
+            "label": timer.label,
+            "media_action": timer.media_action,
+            "media_type": timer.media_type,
+            "notify": timer.notify,
+            "path": timer.path,
+            "priority": timer.priority,
+            "repeat": timer.repeat,
+            "resume": timer.resume,
+            "shuffle": timer.shuffle,
+            "start": timer.start,
+            "start_offset": timer.start_offset,
+            "system_action": timer.system_action,
+            "vol_min": timer.vol_min,
+            "vol_max": timer.vol_max
+        }
+
+        storage = self._load_from_storage()
+        idx = self._find_item_index(storage, timer.id)
+        if idx == -1:
+            storage.append(item)
+        else:
+            storage[idx] = item
+
+        self._save_to_storage(storage)
+
+    def delete_timer(self, timer_id: int) -> None:
+
+        storage = self._load_from_storage()
+        idx = self._find_item_index(storage, timer_id)
+        if idx >= 0:
+            storage.pop(idx)
+            self._save_to_storage(storage=storage)
+
+    def get_scheduled_timers(self) -> 'list[Timer]':
+
+        timers = self.load_timers_from_storage()
+        scheduled_timers = list([timer for timer in timers if timer.days])
+        scheduled_timers.sort(key=lambda timer: (timer.days, timer.start,
+                                                 timer.media_action, timer.system_action))
+        return scheduled_timers
+
+    def get_next_id(self) -> int:
+
+        storage = self._load_from_storage()
+
+        next_id = 0
+        if storage:
+            next_id = max(storage, key=lambda item: item["id"])["id"] + 1
+
+        return next_id

--- a/script.timers/resources/lib/utils/vfs_utils.py
+++ b/script.timers/resources/lib/utils/vfs_utils.py
@@ -18,7 +18,7 @@ _VIDEO_DB_PREFIX = "videodb://"
 _AUDIO_PLUGIN_PREFIX = "plugin://plugin.audio."
 _VIDEO_PLUGIN_PREFIX = "plugin://plugin.video."
 _URI_MATCHER = "^[a-z]+://.+$"
-_FAVOURITES_MATCHER = "^favourites://(PlayMedia|RunScript)\(%22(.+)%22\)/$"
+_FAVOURITES_MATCHER = "^favourites://(PlayMedia|RunScript)\(%22(.+)%22\)/?$"
 _SCRIPT_MATCHER = "^((script|plugin)://)?script\..+$"
 
 _PLAYLIST_TYPES = [".m3u", ".m3u8", ".pls"]

--- a/script.timers/resources/settings.xml
+++ b/script.timers/resources/settings.xml
@@ -76,6 +76,40 @@
             <dependency type="visible" setting="timer_id" operator="!is">-1</dependency>
           </dependencies>
         </setting>
+        <setting id="timer_priority" type="integer" label="32028" help="32336">
+          <level>3</level>
+          <default>0</default>
+          <constraints>
+            <minimum>-15</minimum>
+            <step>1</step>
+            <maximum>15</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_id" operator="!is">-1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_priority_hint" type="string" label="32337" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32337</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_id" operator="!is">-1</condition>
+                <condition setting="timer_priority" operator="gt">10</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
         <dependencies>
           <dependency type="visible" setting="timer_id" operator="!is">-1</dependency>
         </dependencies>
@@ -401,6 +435,7 @@
               <option label="32084">3</option>
               <option label="32085">4</option>
               <option label="32086">5</option>
+              <option label="32093">6</option>
             </options>
           </constraints>
           <control type="spinner" format="string" />
@@ -471,7 +506,7 @@
         </setting>
       </group>
     </category>
-    <category id="c_sleep_timer" label="32004" help="">
+    <category id="c_presets" label="32030" help="">
       <group id="g_sleep_presets" label="32033">
         <setting id="sleep_default_duration" type="time" label="32064" help="32335">
           <level>1</level>
@@ -523,8 +558,6 @@
           <control type="spinner" format="string" />
         </setting>
       </group>
-    </category>
-    <category id="c_snooze_timer" label="32005" help="">
       <group id="g_snooze_presets" label="32038">
         <setting id="snooze_default_duration" type="time" label="32064" help="32335">
           <level>1</level>
@@ -532,6 +565,20 @@
           <control type="button" format="time">
             <heading>32064</heading>
           </control>
+        </setting>
+      </group>
+      <group id="g_quicktimer_presets" label="32180">
+        <setting id="quicktimer_priority" type="integer" label="32028" help="32386">
+          <level>3</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32181">0</option>
+              <option label="32182">1</option>
+              <option label="32183">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
         </setting>
       </group>
     </category>

--- a/test/test_datetime_utils.py
+++ b/test/test_datetime_utils.py
@@ -1,6 +1,4 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.utils import datetime_utils

--- a/test/test_period.py
+++ b/test/test_period.py
@@ -1,0 +1,737 @@
+import unittest
+from datetime import timedelta
+
+from resources.lib.test.mockplayer import VIDEO
+from resources.lib.test.mockstorage import MockStorage
+from resources.lib.timer.period import Period
+from resources.lib.timer.timer import (END_TYPE_TIME, FADE_OFF,
+                                       MEDIA_ACTION_START_STOP)
+
+
+class TestPeriod(unittest.TestCase):
+
+    _t = ["%i:00" % i for i in range(10)]
+
+    def test_compare_1(self):
+        """
+        Period 1         |---------|
+        Period 2                        |--------------|
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[4],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[5],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        td_start, td_end, td_length = timers[0].periods[0].compare(
+            timers[1].periods[0])
+        self.assertEquals(td_start, timedelta(hours=-3))
+        self.assertEquals(td_end, timedelta(hours=-4))
+        self.assertIsNone(td_length)
+
+        td_start, td_end, td_length = timers[1].periods[0].compare(
+            timers[0].periods[0])
+        self.assertEquals(td_start, timedelta(hours=3))
+        self.assertEquals(td_end, timedelta(hours=4))
+        self.assertIsNone(td_length)
+
+    def test_compare_2(self):
+        """
+        Period 1         |---------|
+        Period 2                   |--------------|
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[4],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[4],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        td_start, td_end, td_length = timers[0].periods[0].compare(
+            timers[1].periods[0])
+        self.assertEquals(td_start, timedelta(hours=-2))
+        self.assertEquals(td_end, timedelta(hours=-3))
+        self.assertEquals(td_length, timedelta())
+
+        td_start, td_end, td_length = timers[1].periods[0].compare(
+            timers[0].periods[0])
+        self.assertEquals(td_start, timedelta(hours=2))
+        self.assertEquals(td_end, timedelta(hours=3))
+        self.assertEquals(td_length, timedelta())
+
+    def test_compare_3(self):
+        """
+        Period 1         |---------|
+        Period 2              |--------------|
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[4],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[6],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        td_start, td_end, td_length = timers[0].periods[0].compare(
+            timers[1].periods[0])
+        self.assertEquals(td_start, timedelta(hours=-1))
+        self.assertEquals(td_end, timedelta(hours=-2))
+        self.assertEquals(td_length, timedelta(hours=1))
+
+        td_start, td_end, td_length = timers[1].periods[0].compare(
+            timers[0].periods[0])
+        self.assertEquals(td_start, timedelta(hours=1))
+        self.assertEquals(td_end, timedelta(hours=2))
+        self.assertEquals(td_length, timedelta(hours=1))
+
+    def test_compare_4(self):
+        """
+        Period 1         |---------|
+        Period 2         |---------|
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[4],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[4],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        td_start, td_end, td_length = timers[0].periods[0].compare(
+            timers[1].periods[0])
+        self.assertEquals(td_start, timedelta())
+        self.assertEquals(td_end, timedelta())
+        self.assertEquals(td_length, timedelta(hours=2))
+
+        td_start, td_end, td_length = timers[1].periods[0].compare(
+            timers[0].periods[0])
+        self.assertEquals(td_start, timedelta())
+        self.assertEquals(td_end, timedelta())
+        self.assertEquals(td_length, timedelta(hours=2))
+
+    def test_compare_5(self):
+        """
+        Period 1         |--------------|
+        Period 2              |---------|
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        td_start, td_end, td_length = timers[0].periods[0].compare(
+            timers[1].periods[0])
+        self.assertEquals(td_start, timedelta(hours=-1))
+        self.assertEquals(td_end, timedelta())
+        self.assertEquals(td_length, timedelta(hours=2))
+
+        td_start, td_end, td_length = timers[1].periods[0].compare(
+            timers[0].periods[0])
+        self.assertEquals(td_start, timedelta(hours=1))
+        self.assertEquals(td_end, timedelta())
+        self.assertEquals(td_length, timedelta(hours=2))
+
+    def test_compare_6(self):
+        """
+        Period 1         |--------------|
+        Period 2         |---------|
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[4],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        td_start, td_end, td_length = timers[0].periods[0].compare(
+            timers[1].periods[0])
+        self.assertEquals(td_start, timedelta())
+        self.assertEquals(td_end, timedelta(hours=1))
+        self.assertEquals(td_length, timedelta(hours=2))
+
+        td_start, td_end, td_length = timers[1].periods[0].compare(
+            timers[0].periods[0])
+        self.assertEquals(td_start, timedelta())
+        self.assertEquals(td_end, timedelta(hours=-1))
+        self.assertEquals(td_length, timedelta(hours=2))
+
+    def test_compare_7(self):
+        """
+        Period 1         |-------------------|
+        Period 2              |---------|
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[6],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        td_start, td_end, td_length = timers[0].periods[0].compare(
+            timers[1].periods[0])
+        self.assertEquals(td_start, timedelta(hours=-1))
+        self.assertEquals(td_end, timedelta(hours=1))
+        self.assertEquals(td_length, timedelta(hours=2))
+
+        td_start, td_end, td_length = timers[1].periods[0].compare(
+            timers[0].periods[0])
+        self.assertEquals(td_start, timedelta(hours=1))
+        self.assertEquals(td_end, timedelta(hours=-1))
+        self.assertEquals(td_length, timedelta(hours=2))
+
+    def test_hit_1(self):
+        """
+        Period 1         |---------|
+        Timestamp   x
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        period1 = Period(timedelta(hours=2), timedelta(hours=4))
+        timestamp = timedelta(hours=1)
+
+        s, e, b = period1.hit(timestamp)
+        self.assertEquals(s, timedelta(hours=1))
+        self.assertEquals(e, timedelta(hours=3))
+        self.assertEquals(b, False)
+
+    def test_hit_2(self):
+        """
+        Period 1         |---------|
+        Timestamp        x
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        period1 = Period(timedelta(hours=2), timedelta(hours=4))
+        timestamp = timedelta(hours=2)
+
+        s, e, b = period1.hit(timestamp)
+        self.assertEquals(s, timedelta(hours=0))
+        self.assertEquals(e, timedelta(hours=2))
+        self.assertEquals(b, True)
+
+    def test_hit_3(self):
+        """
+        Period 1         |---------|
+        Timestamp             x
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        period1 = Period(timedelta(hours=2), timedelta(hours=4))
+        timestamp = timedelta(hours=3)
+
+        s, e, b = period1.hit(timestamp)
+        self.assertEquals(s, timedelta(hours=-1))
+        self.assertEquals(e, timedelta(hours=1))
+        self.assertEquals(b, True)
+
+    def test_hit_4(self):
+        """
+        Period 1         |---------|
+        Timestamp                  x
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        period1 = Period(timedelta(hours=2), timedelta(hours=4))
+        timestamp = timedelta(hours=4)
+
+        s, e, b = period1.hit(timestamp)
+        self.assertEquals(s, timedelta(hours=-2))
+        self.assertEquals(e, timedelta(hours=0))
+        self.assertEquals(b, True)
+
+    def test_hit_5(self):
+        """
+        Period 1         |---------|
+        Timestamp                       x
+
+        t       |---t1---t2---t3---t4---t5---t6---t7---t8---t9---t10--->
+        """
+
+        period1 = Period(timedelta(hours=2), timedelta(hours=4))
+        timestamp = timedelta(hours=5)
+
+        s, e, b = period1.hit(timestamp)
+        self.assertEquals(s, timedelta(hours=-3))
+        self.assertEquals(e, timedelta(hours=-1))
+        self.assertEquals(b, False)

--- a/test/test_scheduleraction_tc1_1.py
+++ b/test/test_scheduleraction_tc1_1.py
@@ -1,10 +1,9 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import AUDIO, PICTURE, VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION,
                                        FADE_OUT_FROM_CURRENT,
@@ -12,6 +11,7 @@ from resources.lib.timer.timer import (END_TYPE_DURATION,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_1_1(unittest.TestCase):
@@ -43,7 +43,7 @@ class TestSchedulerActions_1_1(unittest.TestCase):
 
         # ------------ setup player ------------d
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         player.setVolume(100)
 
         # ------------ setup timers ------------
@@ -81,7 +81,8 @@ class TestSchedulerActions_1_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -104,7 +105,8 @@ class TestSchedulerActions_1_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -131,7 +133,8 @@ class TestSchedulerActions_1_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -159,7 +162,8 @@ class TestSchedulerActions_1_1(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -185,7 +189,8 @@ class TestSchedulerActions_1_1(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)

--- a/test/test_scheduleraction_tc1_2.py
+++ b/test/test_scheduleraction_tc1_2.py
@@ -1,16 +1,16 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import AUDIO, PICTURE, VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_IN_FROM_MIN,
                                        MEDIA_ACTION_START_STOP, STATE_ENDING,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_1_2(unittest.TestCase):
@@ -47,7 +47,7 @@ class TestSchedulerActions_1_2(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -84,7 +84,8 @@ class TestSchedulerActions_1_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -108,7 +109,8 @@ class TestSchedulerActions_1_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -136,7 +138,8 @@ class TestSchedulerActions_1_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -165,7 +168,8 @@ class TestSchedulerActions_1_2(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -192,7 +196,8 @@ class TestSchedulerActions_1_2(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)

--- a/test/test_scheduleraction_tc1_3.py
+++ b/test/test_scheduleraction_tc1_3.py
@@ -1,10 +1,9 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import AUDIO, PICTURE, VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION,
                                        FADE_OUT_FROM_CURRENT,
@@ -12,6 +11,7 @@ from resources.lib.timer.timer import (END_TYPE_DURATION,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_1_3(unittest.TestCase):
@@ -48,7 +48,7 @@ class TestSchedulerActions_1_3(unittest.TestCase):
         player.play(playlist)
         player.setVolume(80)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -85,7 +85,8 @@ class TestSchedulerActions_1_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
@@ -108,7 +109,8 @@ class TestSchedulerActions_1_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(apwpl[VIDEO].playlist[0]
@@ -132,7 +134,8 @@ class TestSchedulerActions_1_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
         self.assertEqual(player.getVolume(), 80)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(apwpl[VIDEO].playlist[0]
@@ -156,7 +159,8 @@ class TestSchedulerActions_1_3(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -182,7 +186,8 @@ class TestSchedulerActions_1_3(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)

--- a/test/test_scheduleraction_tc1_4.py
+++ b/test/test_scheduleraction_tc1_4.py
@@ -1,10 +1,9 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import AUDIO, PICTURE, VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION,
                                        FADE_OUT_FROM_CURRENT,
@@ -12,6 +11,7 @@ from resources.lib.timer.timer import (END_TYPE_DURATION,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_1_4(unittest.TestCase):
@@ -43,7 +43,7 @@ class TestSchedulerActions_1_4(unittest.TestCase):
 
         # ------------ setup player ------------d
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         player.setVolume(100)
 
         # ------------ setup timers ------------
@@ -83,7 +83,8 @@ class TestSchedulerActions_1_4(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -107,7 +108,8 @@ class TestSchedulerActions_1_4(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(PICTURE in apwpl, True)
@@ -134,7 +136,8 @@ class TestSchedulerActions_1_4(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(PICTURE in apwpl, True)
@@ -162,7 +165,8 @@ class TestSchedulerActions_1_4(unittest.TestCase):
             schedulderaction.timerToStopSlideshow.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -188,7 +192,8 @@ class TestSchedulerActions_1_4(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)

--- a/test/test_scheduleraction_tc2_1.py
+++ b/test/test_scheduleraction_tc2_1.py
@@ -1,16 +1,16 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import AUDIO, PICTURE, VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        MEDIA_ACTION_START_STOP, STATE_ENDING,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_2_1(unittest.TestCase):
@@ -41,7 +41,7 @@ class TestSchedulerActions_2_1(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -98,7 +98,8 @@ class TestSchedulerActions_2_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -122,7 +123,8 @@ class TestSchedulerActions_2_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -149,7 +151,8 @@ class TestSchedulerActions_2_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -177,7 +180,8 @@ class TestSchedulerActions_2_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -204,7 +208,8 @@ class TestSchedulerActions_2_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -231,7 +236,8 @@ class TestSchedulerActions_2_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -258,7 +264,8 @@ class TestSchedulerActions_2_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -285,7 +292,8 @@ class TestSchedulerActions_2_1(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -309,7 +317,8 @@ class TestSchedulerActions_2_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)

--- a/test/test_scheduleraction_tc2_2.py
+++ b/test/test_scheduleraction_tc2_2.py
@@ -1,16 +1,16 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import AUDIO, PICTURE, VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        MEDIA_ACTION_START_STOP, STATE_ENDING,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_2_2(unittest.TestCase):
@@ -43,7 +43,7 @@ class TestSchedulerActions_2_2(unittest.TestCase):
         playlist = player._buildPlaylist(["Media M1"], VIDEO)
         player.play(playlist)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -100,7 +100,8 @@ class TestSchedulerActions_2_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -125,7 +126,8 @@ class TestSchedulerActions_2_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -154,7 +156,8 @@ class TestSchedulerActions_2_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -184,7 +187,8 @@ class TestSchedulerActions_2_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -213,7 +217,8 @@ class TestSchedulerActions_2_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -242,7 +247,8 @@ class TestSchedulerActions_2_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -271,7 +277,8 @@ class TestSchedulerActions_2_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -301,7 +308,8 @@ class TestSchedulerActions_2_2(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -327,7 +335,8 @@ class TestSchedulerActions_2_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)

--- a/test/test_scheduleraction_tc2_3.py
+++ b/test/test_scheduleraction_tc2_3.py
@@ -1,16 +1,16 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        MEDIA_ACTION_START_STOP, STATE_ENDING,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_2_3(unittest.TestCase):
@@ -43,7 +43,7 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         playlist = player._buildPlaylist(["Media M1"], VIDEO)
         player.play(playlist)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -100,7 +100,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -125,7 +126,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -150,7 +152,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -175,7 +178,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -200,7 +204,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -225,7 +230,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -250,7 +256,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -275,7 +282,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -298,7 +306,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -324,7 +333,7 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         playlist = player._buildPlaylist(["Media M1"], VIDEO)
         player.play(playlist)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -381,7 +390,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -405,7 +415,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -430,7 +441,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -455,7 +467,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -484,7 +497,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -513,7 +527,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -538,7 +553,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -563,7 +579,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -586,7 +603,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -611,7 +629,7 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         playlist = player._buildPlaylist(["Media M1"], VIDEO)
         player.play(playlist)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -668,7 +686,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -692,7 +711,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -721,7 +741,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -750,7 +771,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -774,7 +796,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -799,7 +822,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -824,7 +848,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -849,7 +874,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -872,7 +898,8 @@ class TestSchedulerActions_2_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)

--- a/test/test_scheduleraction_tc3_1.py
+++ b/test/test_scheduleraction_tc3_1.py
@@ -1,16 +1,16 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        MEDIA_ACTION_START_STOP, STATE_ENDING,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_3_1(unittest.TestCase):
@@ -39,7 +39,7 @@ class TestSchedulerActions_3_1(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -98,7 +98,8 @@ class TestSchedulerActions_3_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -122,7 +123,8 @@ class TestSchedulerActions_3_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -149,7 +151,8 @@ class TestSchedulerActions_3_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -177,7 +180,8 @@ class TestSchedulerActions_3_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -204,7 +208,8 @@ class TestSchedulerActions_3_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -232,7 +237,8 @@ class TestSchedulerActions_3_1(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -254,7 +260,8 @@ class TestSchedulerActions_3_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)

--- a/test/test_scheduleraction_tc3_2.py
+++ b/test/test_scheduleraction_tc3_2.py
@@ -1,16 +1,16 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        MEDIA_ACTION_START_STOP, STATE_ENDING,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_3_2(unittest.TestCase):
@@ -44,7 +44,7 @@ class TestSchedulerActions_3_2(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -101,7 +101,8 @@ class TestSchedulerActions_3_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -126,7 +127,8 @@ class TestSchedulerActions_3_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -155,7 +157,8 @@ class TestSchedulerActions_3_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -185,7 +188,8 @@ class TestSchedulerActions_3_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -214,7 +218,8 @@ class TestSchedulerActions_3_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -244,7 +249,8 @@ class TestSchedulerActions_3_2(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -268,7 +274,8 @@ class TestSchedulerActions_3_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)

--- a/test/test_scheduleraction_tc3_3.py
+++ b/test/test_scheduleraction_tc3_3.py
@@ -1,16 +1,16 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        MEDIA_ACTION_START_STOP, STATE_ENDING,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_3_3(unittest.TestCase):
@@ -44,7 +44,7 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -101,7 +101,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -126,7 +127,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -151,7 +153,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -177,7 +180,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -202,7 +206,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -228,7 +233,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -251,7 +257,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -277,7 +284,7 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -334,7 +341,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -359,7 +367,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -384,7 +393,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -410,7 +420,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -435,7 +446,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -461,7 +473,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -484,7 +497,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -510,7 +524,7 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -567,7 +581,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -592,7 +607,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -621,7 +637,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -651,7 +668,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -676,7 +694,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -702,7 +721,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -725,7 +745,8 @@ class TestSchedulerActions_3_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)

--- a/test/test_scheduleraction_tc4_1.py
+++ b/test/test_scheduleraction_tc4_1.py
@@ -1,16 +1,16 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        MEDIA_ACTION_START_STOP, STATE_ENDING,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_4_1(unittest.TestCase):
@@ -40,10 +40,10 @@ class TestSchedulerActions_4_1(unittest.TestCase):
         # ------------ setup player ------------
         player = MockPlayer()
         player.setSeekDelayedTimer(True)
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         player.setVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -100,7 +100,8 @@ class TestSchedulerActions_4_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -125,7 +126,8 @@ class TestSchedulerActions_4_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -154,7 +156,8 @@ class TestSchedulerActions_4_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -184,7 +187,8 @@ class TestSchedulerActions_4_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -213,7 +217,8 @@ class TestSchedulerActions_4_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -243,7 +248,8 @@ class TestSchedulerActions_4_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -273,7 +279,8 @@ class TestSchedulerActions_4_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -303,7 +310,8 @@ class TestSchedulerActions_4_1(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -327,7 +335,8 @@ class TestSchedulerActions_4_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)

--- a/test/test_scheduleraction_tc4_2.py
+++ b/test/test_scheduleraction_tc4_2.py
@@ -1,11 +1,10 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import VIDEO
 from resources.lib.player.player_utils import REPEAT_ALL, REPEAT_OFF
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_IN_FROM_MIN,
                                        FADE_OUT_FROM_MAX,
@@ -13,6 +12,7 @@ from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_IN_FROM_MIN,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_4_2(unittest.TestCase):
@@ -50,7 +50,7 @@ class TestSchedulerActions_4_2(unittest.TestCase):
         player.setRepeat(REPEAT_ALL)
         player.setVolume(80)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -109,7 +109,8 @@ class TestSchedulerActions_4_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -137,7 +138,8 @@ class TestSchedulerActions_4_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -168,7 +170,8 @@ class TestSchedulerActions_4_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -201,7 +204,8 @@ class TestSchedulerActions_4_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -233,7 +237,8 @@ class TestSchedulerActions_4_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -266,7 +271,8 @@ class TestSchedulerActions_4_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -300,7 +306,8 @@ class TestSchedulerActions_4_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -333,7 +340,8 @@ class TestSchedulerActions_4_2(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -360,7 +368,8 @@ class TestSchedulerActions_4_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)

--- a/test/test_scheduleraction_tc4_3.py
+++ b/test/test_scheduleraction_tc4_3.py
@@ -1,11 +1,10 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import VIDEO
 from resources.lib.player.player_utils import REPEAT_ALL, REPEAT_OFF
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        FADE_OUT_FROM_CURRENT,
@@ -14,6 +13,7 @@ from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_4_3(unittest.TestCase):
@@ -48,7 +48,7 @@ class TestSchedulerActions_4_3(unittest.TestCase):
         player.setDefaultVolume(100)
         player.setVolume(80)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -331,7 +331,7 @@ class TestSchedulerActions_4_3(unittest.TestCase):
         player.setShuffled(True)
         player.setRepeat(REPEAT_ALL)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -652,7 +652,7 @@ class TestSchedulerActions_4_3(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -933,7 +933,7 @@ class TestSchedulerActions_4_3(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         player.setVolume(100)
 
         # ------------ setup timers ------------
@@ -1212,7 +1212,7 @@ class TestSchedulerActions_4_3(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         player.setVolume(100)
 
         # ------------ setup timers ------------
@@ -1503,7 +1503,7 @@ class TestSchedulerActions_4_3(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -1812,7 +1812,7 @@ class TestSchedulerActions_4_3(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)

--- a/test/test_scheduleraction_tc5_1.py
+++ b/test/test_scheduleraction_tc5_1.py
@@ -1,10 +1,9 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import AUDIO, PICTURE, VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_IN_FROM_MIN,
                                        FADE_OUT_FROM_CURRENT,
@@ -12,6 +11,7 @@ from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_IN_FROM_MIN,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_5_1_1(unittest.TestCase):
@@ -44,7 +44,7 @@ class TestSchedulerActions_5_1_1(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         playlist = player._buildPlaylist(["Pictures"], PICTURE)
         player.play(playlist)
         player.setVolume(100)
@@ -84,7 +84,8 @@ class TestSchedulerActions_5_1_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(PICTURE in apwpl, True)
@@ -108,7 +109,8 @@ class TestSchedulerActions_5_1_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -138,7 +140,8 @@ class TestSchedulerActions_5_1_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -169,7 +172,8 @@ class TestSchedulerActions_5_1_1(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -196,7 +200,8 @@ class TestSchedulerActions_5_1_1(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -241,7 +246,7 @@ class TestSchedulerActions_5_1_2(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         playlist = player._buildPlaylist(["Audio M1"], AUDIO)
         player.play(playlist)
         player.setVolume(80)
@@ -281,7 +286,8 @@ class TestSchedulerActions_5_1_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(AUDIO in apwpl, True)
@@ -305,7 +311,8 @@ class TestSchedulerActions_5_1_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -337,7 +344,8 @@ class TestSchedulerActions_5_1_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -370,7 +378,8 @@ class TestSchedulerActions_5_1_2(unittest.TestCase):
             schedulderaction.timerToStopSlideshow.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -398,7 +407,8 @@ class TestSchedulerActions_5_1_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture

--- a/test/test_scheduleraction_tc5_2.py
+++ b/test/test_scheduleraction_tc5_2.py
@@ -1,16 +1,16 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import AUDIO, PICTURE, VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_IN_FROM_MIN,
                                        FADE_OFF, MEDIA_ACTION_START_STOP,
                                        STATE_ENDING, STATE_RUNNING,
                                        STATE_STARTING, STATE_WAITING,
                                        SYSTEM_ACTION_NONE, Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_5_2(unittest.TestCase):
@@ -44,7 +44,7 @@ class TestSchedulerActions_5_2(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         playlist = player._buildPlaylist(["Video M1"], VIDEO)
         player.play(playlist)
         player.setVolume(100)
@@ -103,7 +103,8 @@ class TestSchedulerActions_5_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -130,7 +131,8 @@ class TestSchedulerActions_5_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -166,7 +168,8 @@ class TestSchedulerActions_5_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -205,7 +208,8 @@ class TestSchedulerActions_5_2(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture / Audio
@@ -238,7 +242,7 @@ class TestSchedulerActions_5_2(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         playlist = player._buildPlaylist(["Pictures M1"], PICTURE)
         player.play(playlist)
 
@@ -281,7 +285,8 @@ class TestSchedulerActions_5_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(PICTURE in apwpl, True)
@@ -308,7 +313,8 @@ class TestSchedulerActions_5_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Video
@@ -341,7 +347,8 @@ class TestSchedulerActions_5_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Video
@@ -374,7 +381,8 @@ class TestSchedulerActions_5_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(PICTURE in apwpl, True)
@@ -400,7 +408,8 @@ class TestSchedulerActions_5_2(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(PICTURE in apwpl, True)

--- a/test/test_scheduleraction_tc5_3.py
+++ b/test/test_scheduleraction_tc5_3.py
@@ -1,16 +1,16 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import AUDIO, PICTURE, VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        MEDIA_ACTION_START_STOP, STATE_ENDING,
                                        STATE_RUNNING, STATE_STARTING,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
 class TestSchedulerActions_5_3(unittest.TestCase):
@@ -39,7 +39,7 @@ class TestSchedulerActions_5_3(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         player.setVolume(100)
 
         # ------------ setup timers ------------
@@ -96,7 +96,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -119,7 +120,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -146,7 +148,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -175,7 +178,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -203,7 +207,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -231,7 +236,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -259,7 +265,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -288,7 +295,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
             schedulderaction.timerToStopSlideshow.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -314,7 +322,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -338,7 +347,7 @@ class TestSchedulerActions_5_3(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         player.setVolume(100)
         playlist = player._buildPlaylist(["Video M1"], VIDEO)
         player.play(playlist)
@@ -397,7 +406,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 1)
@@ -421,7 +431,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -449,7 +460,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -479,7 +491,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -508,7 +521,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -538,7 +552,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
             schedulderaction.timerToStopSlideshow.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -567,7 +582,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -595,7 +611,7 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         player = MockPlayer()
         player.setSeekDelayedTimer(True)
         player._slideShowStaytime = 60
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         player.setVolume(100)
 
         # ------------ setup timers ------------
@@ -653,7 +669,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -677,7 +694,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -705,7 +723,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -735,7 +754,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -764,7 +784,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -794,7 +815,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -823,7 +845,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -853,7 +876,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
             schedulderaction.timerToStopSlideshow.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -880,7 +904,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -904,7 +929,7 @@ class TestSchedulerActions_5_3(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         player.setVolume(100)
         playlist = player._buildPlaylist(["Video M1"], VIDEO)
         player.play(playlist)
@@ -963,7 +988,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 1)
@@ -987,7 +1013,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1015,7 +1042,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1045,7 +1073,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1074,7 +1103,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1104,7 +1134,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1132,7 +1163,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1162,7 +1194,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
             schedulderaction.timerToStopSlideshow.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 1)
@@ -1190,7 +1223,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 1)
@@ -1216,7 +1250,7 @@ class TestSchedulerActions_5_3(unittest.TestCase):
 
         # ------------ setup player ------------
         player = MockPlayer()
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         player.setVolume(100)
         playlist = player._buildPlaylist(["Video M1"], VIDEO)
         player.play(playlist)
@@ -1275,7 +1309,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 1)
@@ -1299,7 +1334,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1327,7 +1363,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1357,7 +1394,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1386,7 +1424,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1415,7 +1454,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1444,7 +1484,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         # Picture
@@ -1474,7 +1515,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
             schedulderaction.timerToStopSlideshow.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 1)
@@ -1502,7 +1544,8 @@ class TestSchedulerActions_5_3(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopSlideshow, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 1)

--- a/test/test_scheduleraction_tc6_1.py
+++ b/test/test_scheduleraction_tc6_1.py
@@ -1,10 +1,9 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import AUDIO, PICTURE, VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        FADE_OUT_FROM_CURRENT,
@@ -15,9 +14,10 @@ from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_OFF,
                                        STATE_WAITING, SYSTEM_ACTION_NONE,
                                        SYSTEM_ACTION_SHUTDOWN_KODI, Period,
                                        Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
-class TestSchedulerActions_6(unittest.TestCase):
+class TestSchedulerActions_6_1(unittest.TestCase):
 
     _t0 = 0
     _t1 = 60
@@ -49,7 +49,7 @@ class TestSchedulerActions_6(unittest.TestCase):
         player.setDefaultVolume(100)
         player.setVolume(80)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
         schedulderaction.__is_unit_test__ = True
 
         # ------------ setup timers ------------
@@ -107,7 +107,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -132,7 +133,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -161,7 +163,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -194,7 +197,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction.id, timers[0].id)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -222,7 +226,7 @@ class TestSchedulerActions_6(unittest.TestCase):
         player.setVolume(80)
         player.play(playlist)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -279,7 +283,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -303,7 +308,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -327,7 +333,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -352,7 +359,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -381,7 +389,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -411,7 +420,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -436,7 +446,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -462,7 +473,8 @@ class TestSchedulerActions_6(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -487,7 +499,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -514,7 +527,7 @@ class TestSchedulerActions_6(unittest.TestCase):
         player.setVolume(80)
         player.play(playlist)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -571,7 +584,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -596,7 +610,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -625,7 +640,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -655,7 +671,8 @@ class TestSchedulerActions_6(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -678,7 +695,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -702,7 +720,8 @@ class TestSchedulerActions_6(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -725,7 +744,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -749,7 +769,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t7)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t7)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -776,7 +797,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t8)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t8)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)

--- a/test/test_scheduleraction_tc6_2.py
+++ b/test/test_scheduleraction_tc6_2.py
@@ -1,19 +1,19 @@
 import unittest
-
-from resources.lib.utils.datetime_utils import DateTimeDelta
 from datetime import datetime, timedelta
 
 from resources.lib.player.mediatype import AUDIO, PICTURE, VIDEO
 from resources.lib.test.mockplayer import MockPlayer
+from resources.lib.test.mockstorage import MockStorage
 from resources.lib.timer.scheduleraction import SchedulerAction
 from resources.lib.timer.timer import (END_TYPE_DURATION, FADE_IN_FROM_MIN,
                                        FADE_OFF, MEDIA_ACTION_START_STOP,
                                        STATE_ENDING, STATE_RUNNING,
                                        STATE_STARTING, STATE_WAITING,
                                        SYSTEM_ACTION_NONE, Period, Timer)
+from resources.lib.utils.datetime_utils import DateTimeDelta
 
 
-class TestSchedulerActions_6(unittest.TestCase):
+class TestSchedulerActions_6_2(unittest.TestCase):
 
     _t0 = 0
     _t1 = 60
@@ -49,7 +49,7 @@ class TestSchedulerActions_6(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -87,7 +87,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -112,7 +113,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -143,7 +145,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -169,7 +172,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -195,7 +199,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -228,7 +233,7 @@ class TestSchedulerActions_6(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -266,7 +271,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -291,7 +297,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -322,7 +329,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         apwpl = player.getActivePlayersWithPlaylist()
@@ -349,7 +357,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(len(apwpl), 0)
@@ -375,7 +384,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         apwpl = player.getActivePlayersWithPlaylist()
@@ -409,7 +419,7 @@ class TestSchedulerActions_6(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -447,7 +457,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -472,7 +483,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -503,7 +515,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -531,7 +544,8 @@ class TestSchedulerActions_6(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[0].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -558,7 +572,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(
             schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -585,7 +600,7 @@ class TestSchedulerActions_6(unittest.TestCase):
         player.play(playlist)
         player.setDefaultVolume(100)
 
-        schedulderaction = SchedulerAction(player)
+        schedulderaction = SchedulerAction(player, MockStorage())
 
         # ------------ setup timers ------------
         # Timer 1 (T1)
@@ -642,7 +657,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t0)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t0)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -667,7 +683,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t1)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t1)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -696,7 +713,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t2)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t2)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -726,7 +744,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t3)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t3)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -755,7 +774,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t4)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t4)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -785,7 +805,8 @@ class TestSchedulerActions_6(unittest.TestCase):
             schedulderaction.timerToStopAV.id, timers[1].id)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t5)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t5)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)
@@ -809,7 +830,8 @@ class TestSchedulerActions_6(unittest.TestCase):
         self.assertEqual(schedulderaction.timerToStopAV, None)
         self.assertEqual(schedulderaction.timerWithSystemAction, None)
 
-        schedulderaction.perform(DateTimeDelta(datetime.utcfromtimestamp(60 * self._t6)))
+        schedulderaction.perform(DateTimeDelta(
+            datetime.utcfromtimestamp(60 * self._t6)))
 
         apwpl = player.getActivePlayersWithPlaylist()
         self.assertEqual(VIDEO in apwpl, True)

--- a/test/test_scheduleraction_tc7_1.py
+++ b/test/test_scheduleraction_tc7_1.py
@@ -1,0 +1,231 @@
+import unittest
+
+from resources.lib.test.mockplayer import VIDEO, MockPlayer
+from resources.lib.test.mockstorage import MockStorage
+from resources.lib.timer.scheduleraction import SchedulerAction
+from resources.lib.timer.timer import (END_TYPE_TIME, FADE_OFF,
+                                       MEDIA_ACTION_START_STOP)
+from resources.lib.utils.datetime_utils import (DateTimeDelta,
+                                                parse_datetime_str)
+
+
+class TestSchedulerActions_7_1(unittest.TestCase):
+
+    _t = ["%i:00" % i for i in range(10)]
+    _dtd = [DateTimeDelta(parse_datetime_str("2023-01-02 %s" % s)) for s in _t]
+
+    def test_tc_7_1_1(self):
+        """
+        Timer 1           |-------------------------|  Prio 1
+        Timer 2                  |------|              Prio 0
+
+        t       |---------|--T1--|--T1--|---T1------|---------->
+                t0        t1 t2  t3 t4  t5   t6     t7   t8
+        Player            play
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(VIDEO).state, None)
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(VIDEO).state, None)
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(VIDEO).state, None)
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(VIDEO).state, None)
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(VIDEO).state, None)
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(VIDEO).state, None)
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()

--- a/test/test_scheduleraction_tc7_2.py
+++ b/test/test_scheduleraction_tc7_2.py
@@ -1,0 +1,1063 @@
+import unittest
+
+from resources.lib.test.mockplayer import VIDEO, MockPlayer
+from resources.lib.test.mockstorage import MockStorage
+from resources.lib.timer.scheduleraction import SchedulerAction
+from resources.lib.timer.timer import (END_TYPE_TIME, FADE_OFF,
+                                       MEDIA_ACTION_START_STOP)
+from resources.lib.utils.datetime_utils import (DateTimeDelta,
+                                                parse_datetime_str)
+
+
+class TestSchedulerActions_7_2(unittest.TestCase):
+
+    _t = ["%i:00" % i for i in range(10)]
+    _dtd = [DateTimeDelta(parse_datetime_str("2023-01-02 %s" % s)) for s in _t]
+
+    def test_tc_7_2_1(self):
+        """
+        Timer 1           |-------------|                 Prio 1
+        Timer 2                  |------------------|     Prio 0
+
+        t       |---------|-----T1------|-----T2----|---------->
+                t0        t1 t2  t3 t4  t5   t6     t7   t8
+        Player            play          play
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[1].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[1].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+    def test_tc_7_2_2(self):
+        """
+        Media 1 |---------|                            |---------------->
+        Timer 1           |------------------R                             Prio 1
+        Timer 2                      |-----------------R                   Prio 0
+
+        t       |----M1---|--------T1--------|---T2----|-------M1-------->
+                t0        t1    t2   t3  t4  t5   t6   t7   t8
+        Player            play               play      resume
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[1].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[1].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[1].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[1].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+    def test_tc_7_2_3(self):
+        """
+        Media 1 |---------|                                
+        Timer 1           |------------------X                             Prio 1
+        Timer 2                      |-----------------R                   Prio 0
+
+        t       |----M1---|---------T1-------|---T2----|---------------->
+                t0        t1    t2   t3  t4  t5   t6   t7   t8
+        Player            play               play      stop
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[1].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[1].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+    def test_tc_7_2_4(self):
+        """
+        Media 1 |---------|                                
+        Timer 1           |------------------X                             Prio 1
+        Timer 2                      |-----------------X                   Prio 0
+
+        t       |----M1---|---------T1-------|---T2----|---------------->
+                t0        t1    t2   t3  t4  t5   t6   t7   t8
+        Player            play               play      stop
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[1].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[1].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+    def test_tc_7_2_5(self):
+        """
+        Media 1 |---------|                  
+        Timer 1           |------------------R                             Prio 1
+        Timer 2                      |-----------------X                   Prio 0
+
+        t       |----M1---|----T1----|-------T2--------|---------------->
+                t0        t1    t2   t3  t4  t5   t6   t7   t8
+        Player            play               play      stop
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[1].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[1].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()

--- a/test/test_scheduleraction_tc7_3.py
+++ b/test/test_scheduleraction_tc7_3.py
@@ -1,0 +1,959 @@
+import unittest
+
+from resources.lib.test.mockplayer import VIDEO, MockPlayer
+from resources.lib.test.mockstorage import MockStorage
+from resources.lib.timer.scheduleraction import SchedulerAction
+from resources.lib.timer.timer import (END_TYPE_TIME, FADE_OFF,
+                                       MEDIA_ACTION_START_STOP)
+from resources.lib.utils.datetime_utils import (DateTimeDelta,
+                                                parse_datetime_str)
+
+
+class TestSchedulerActions_7_3(unittest.TestCase):
+
+    _t = ["%i:00" % i for i in range(10)]
+    _dtd = [DateTimeDelta(parse_datetime_str("2023-01-02 %s" % s)) for s in _t]
+
+    def test_tc_7_3_1(self):
+        """
+        Media 1 |---------|                         |---------------->
+        Timer 1           |-------------------------R                     Prio 1
+        Timer 2                  |------X                                 Prio 0
+
+        t       |----M1---|--T1--|--T2--|---T1------|------M1-------->
+                t0        t1 t2  t3 t4  t5   t6     t7   t8
+        Player            play   play   resume      resume
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+    def test_tc_7_3_2(self):
+        """
+        Media 1 |---------|
+        Timer 1           |-------------------------X                      Prio 1
+        Timer 2                  |------R                                  Prio 0
+
+        t       |----M1---|--T1--|--T2--|---T1------|---------------->
+                t0        t1 t2  t3 t4  t5   t6     t7   t8
+        Player            play   play   resume      stop
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+    def test_tc_7_3_3(self):
+        """
+        Media 1 |---------|                         |---------------->
+        Timer 1           |-------------R                                Prio 1
+        Timer 2                  |------------------X                    Prio 0
+        Timer 3                         |-----------R                    Prio 2
+
+        t       |----M1---|----T1-------|-----T3----|---------------->
+                t0        t1 t2  t3 t4  t5   t6     t7   t8
+        Player            play                      resume
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 3,
+                "label": "Timer 3",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://3/3/3.mp3",
+                "priority": 2,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[5],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+    def test_tc_7_3_4(self):
+        """
+        Media 1 |---------|
+        Timer 1           |-------------R                                Prio 1
+        Timer 2                  |------------------R                    Prio 0
+        Timer 3                         |-----------X                    Prio 2
+
+        t       |----M1---|--T1--|--T2--|------T3---|------M1-------->
+                t0        t1 t2  t3 t4  t5   t6     t7   t8
+        Player            play          play        play
+        """
+
+        data = [
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 3,
+                "label": "Timer 3",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://3/3/3.mp3",
+                "priority": 2,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[5],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[0].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[0].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(len(apwpl), 0)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player.getVolume(), 100)
+
+        schedulderaction.reset()

--- a/test/test_scheduleraction_tc7_4.py
+++ b/test/test_scheduleraction_tc7_4.py
@@ -1,0 +1,1218 @@
+import unittest
+
+from resources.lib.test.mockplayer import VIDEO, MockPlayer
+from resources.lib.test.mockstorage import MockStorage
+from resources.lib.timer.scheduleraction import SchedulerAction
+from resources.lib.timer.timer import (END_TYPE_TIME, FADE_OFF,
+                                       MEDIA_ACTION_START_STOP)
+from resources.lib.utils.datetime_utils import (DateTimeDelta,
+                                                parse_datetime_str)
+
+
+class TestSchedulerActions_7_4(unittest.TestCase):
+
+    _t = ["%i:00" % i for i in range(10)]
+    _dtd = [DateTimeDelta(parse_datetime_str("2023-01-02 %s" % s)) for s in _t]
+
+    def test_tc_7_4_1(self):
+        """
+        Media 1 |---------|                         |---------------->
+        Timer 1                 |-------R                              Prio 0
+        Timer 2              |----------R                              Prio 0
+        Timer 3           |-------------R                              Prio 1
+        Timer 4                         |-----------R                  Prio 1
+        Timer 5                         |----R                         Prio 0
+        t       |----M1---|--|--|-- |---|----|------|----|-------->
+                t0        t1 t2 t3  t4  t5   t6     t7   t8
+        Player            play T3       play T4     resume M1
+        """
+
+        data = [
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 3,
+                "label": "Timer 3",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://3/3/3.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 4,
+                "label": "Timer 4",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://4/4/4.mp3",
+                "priority":1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[5],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[6],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 5,
+                "label": "Timer 5",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://5/5/5.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[5],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[3].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[3].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[3].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[3].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+    def test_tc_7_4_2(self):
+        """
+        Media 1 |---------|                         |---------------->
+        Timer 1                 |-------R                              Prio 0
+        Timer 2              |----------R                              Prio 0
+        Timer 3           |-------------R                              Prio 1
+        Timer 4                         |-----------R                  Prio 0
+        Timer 5                         |----R                         Prio 1
+        t       |----M1---|--|--|-- |---|----|------|----|-------->
+                t0        t1 t2 t3  t4  t5   t6     t7   t8
+        Player            play T3       T5   T4     resume M1
+        """
+
+        data = [
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 3,
+                "label": "Timer 3",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://3/3/3.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 4,
+                "label": "Timer 4",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://4/4/4.mp3",
+                "priority":0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[5],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[6],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 5,
+                "label": "Timer 5",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://5/5/5.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[5],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[4].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[4].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[3].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[3].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+    def test_tc_7_4_3(self):
+        """
+        Media 1 |---------|                         |---------------->
+        Timer 1                 |-------R                              Prio 0
+        Timer 2              |----------R                              Prio 0
+        Timer 3           |-------------R                              Prio 1
+        Timer 4                         |-----------R                  Prio 0
+        Timer 5                         |----R                         Prio 0
+        t       |----M1---|--|--|-- |---|----|------|----|-------->
+                t0        t1 t2 t3  t4  t5   t6     t7   t8
+        Player            play T3       T5   T4     resume M1
+        """
+
+        data = [
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 3,
+                "label": "Timer 3",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://3/3/3.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 4,
+                "label": "Timer 4",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://4/4/4.mp3",
+                "priority":0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[5],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[6],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 5,
+                "label": "Timer 5",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://5/5/5.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[5],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[3].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[3].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[3].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[3].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+    def test_tc_7_4_4(self):
+        """
+        Media 1 |---------|                              |--------->
+        Timer 1                 |-------R                              Prio 0
+        Timer 2              |----------R                              Prio 0
+        Timer 3           |-------------R                              Prio 1
+        Timer 4                         |----------------R             Prio 0
+        Timer 5                         |----R                         Prio 0
+        Timer 6                     |---------------R                  Prio 0
+        t       |----M1---|--|--|-- |---|----|------|----|-------->
+                t0        t1 t2 t3  t4  t5   t6     t7   t8
+        Player            play T3       T5   T4     resume M1
+        """
+
+        data = [
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://1/1/1.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://2/2/2.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 3,
+                "label": "Timer 3",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://3/3/3.mp3",
+                "priority": 1,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 4,
+                "label": "Timer 4",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://4/4/4.mp3",
+                "priority":0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[5],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[6],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 5,
+                "label": "Timer 5",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://5/5/5.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[5],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            },
+            {
+                "days": [
+                    0
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 6,
+                "label": "Timer 6",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "videodb://6/6/6.mp3",
+                "priority": 0,
+                "repeat": False,
+                "resume": True,
+                "shuffle": False,
+                "start": self._t[4],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 80
+            }
+        ]
+
+        player = MockPlayer()
+        player.setVolume(100)
+        playlist = player._buildPlaylist(["Media M1"], VIDEO)
+        player.play(playlist)
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        schedulderaction = SchedulerAction(player, storage)
+
+        # ------------ t0 ------------
+        schedulderaction.calculate(timers, self._dtd[0])
+        schedulderaction.perform(self._dtd[0])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t1 ------------
+        schedulderaction.calculate(timers, self._dtd[1])
+        schedulderaction.perform(self._dtd[1])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t2 ------------
+        schedulderaction.calculate(timers, self._dtd[2])
+        schedulderaction.perform(self._dtd[2])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t3 ------------
+        schedulderaction.calculate(timers, self._dtd[3])
+        schedulderaction.perform(self._dtd[3])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t4 ------------
+        schedulderaction.calculate(timers, self._dtd[4])
+        schedulderaction.perform(self._dtd[4])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[2].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[2].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t5 ------------
+        schedulderaction.calculate(timers, self._dtd[5])
+        schedulderaction.perform(self._dtd[5])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[5].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[5].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t6 ------------
+        schedulderaction.calculate(timers, self._dtd[6])
+        schedulderaction.perform(self._dtd[6])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]
+                         ["file"], timers[5].path)
+        self.assertEqual(player.getVolume(), 100)
+        self.assertNotEqual(player._getResumeStatus(VIDEO), None)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).timer.id, timers[5].id)
+        self.assertEqual(player._getResumeStatus(
+            VIDEO).state.playlist[0]["file"], "Media M1")
+
+        schedulderaction.reset()
+
+        # ------------ t7 ------------
+        schedulderaction.calculate(timers, self._dtd[7])
+        schedulderaction.perform(self._dtd[7])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()
+
+        # ------------ t8 ------------
+        schedulderaction.calculate(timers, self._dtd[8])
+        schedulderaction.perform(self._dtd[8])
+
+        apwpl = player.getActivePlayersWithPlaylist()
+        self.assertEqual(VIDEO in apwpl, True)
+        self.assertEqual(apwpl[VIDEO].playlist[0]["file"], "Media M1")
+        self.assertEqual(player.getVolume(), 100)
+        self.assertEqual(player._getResumeStatus(VIDEO), None)
+
+        schedulderaction.reset()

--- a/test/test_scheduleraction_tc8_1.py
+++ b/test/test_scheduleraction_tc8_1.py
@@ -1,0 +1,2794 @@
+import unittest
+
+from resources.lib.test.mockplayer import AUDIO, PICTURE, VIDEO
+from resources.lib.test.mockstorage import MockStorage
+from resources.lib.timer.concurrency import determine_overlappings
+from resources.lib.timer.timer import (END_TYPE_TIME, FADE_OFF,
+                                       MEDIA_ACTION_START,
+                                       MEDIA_ACTION_START_AT_END,
+                                       MEDIA_ACTION_START_STOP,
+                                       MEDIA_ACTION_STOP,
+                                       MEDIA_ACTION_STOP_AT_END,
+                                       MEDIA_ACTION_STOP_START)
+from resources.lib.utils.datetime_utils import (DateTimeDelta,
+                                                parse_datetime_str)
+
+
+class TestSchedulerActions_8_1(unittest.TestCase):
+
+    _t = ["%i:00" % i for i in range(10)]
+    _dtd = [DateTimeDelta(parse_datetime_str("2023-01-02 %s" % s)) for s in _t]
+
+    def test_tc_8_1_1(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                S---------X                      start-stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_1_2(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                S--------->                      start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_1_3(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                |---------S                      start-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_1_4(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                X---------S                      stop-start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_1_5(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                |---------X                      stop-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_1_6(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                X---------|                      stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_2_1(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2      S---------X                                start-stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_2_2(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2      S--------->                                start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_2_3(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2      |---------S                                start-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_2_4(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2      X---------S                                stop-start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_2_5(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2      |---------X                                stop-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_2_6(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2      X---------|                                stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_3_1(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                               S---------X       start-stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_3_2(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                               S--------->       start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_3_3(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                               |---------S       start-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_3_4(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                               X---------S       stop-start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_3_5(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                               |---------X       stop-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_3_6(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                               X---------|       stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_4_1(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                S---------X                      start-stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_4_2(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                S--------->                      start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_4_3(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                |---------S                      start-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_4_4(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                X---------S                      stop-start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_4_5(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                |---------X                      stop-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_4_6(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                X---------|                      stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_5_1(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2      S---------X                                start-stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_5_2(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2      S--------->                                start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_5_3(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2      |---------S                                start-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_5_4(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2      X---------S                                stop-start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_5_5(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2      |---------X                                stop-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_5_6(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2      X---------|                                stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[3],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[1],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_6_1(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                               S---------X       start-stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_6_2(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                               S--------->       start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_6_3(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                               |---------S       start-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_6_4(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                               X---------S       stop-start/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)
+
+    def test_tc_8_6_5(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                               |---------X       stop-at-end/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP_AT_END,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_6_6(self):
+        """
+        Timer 1           X------------------------S            stop-start/video
+        Timer 2                               X---------|       stop/video
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_STOP_START,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[8],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[6],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_7_1(self):
+        """
+        Timer 1           S------------------------X            start-stop/audio
+        Timer 2                S---------X                      start-stop/picture
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": AUDIO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": PICTURE,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertFalse(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertFalse(b)
+
+    def test_tc_8_7_2(self):
+        """
+        Timer 1           S------------------------X            start-stop/video
+        Timer 2                S---------X                      start-stop/picture
+
+        t       |----|----|----|----|----|----|----|----|----|
+                t0   t1   t2   t3   t4   t5   t6   t7   t8   t9
+        """
+
+        data = [
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[7],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 1,
+                "label": "Timer 1",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": VIDEO,
+                "notify": True,
+                "path": "pvr://channels/radio/Alle%20Kan%C3%A4le/pvr.hts_976717008.pvr",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[2],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            },
+            {
+                "days": [
+                    1
+                ],
+                "duration": "01:00",
+                "duration_offset": 0,
+                "end": self._t[5],
+                "end_offset": 0,
+                "end_type": END_TYPE_TIME,
+                "fade": FADE_OFF,
+                "id": 2,
+                "label": "Timer 2",
+                "media_action": MEDIA_ACTION_START_STOP,
+                "media_type": PICTURE,
+                "notify": True,
+                "path": "/home/heckie/pictures/",
+                "priority": 0,
+                "repeat": False,
+                "resume": False,
+                "shuffle": False,
+                "start": self._t[3],
+                "start_offset": 0,
+                "system_action": 0,
+                "vol_max": 100,
+                "vol_min": 75
+            }
+        ]
+
+        storage = MockStorage(data=data)
+        timers = storage.load_timers_from_storage()
+
+        b = determine_overlappings(timers[0], timers[1:])
+        self.assertTrue(b)
+
+        b = determine_overlappings(timers[1], timers[:1])
+        self.assertTrue(b)


### PR DESCRIPTION
v3.5.0 (2023-02-07)
- New feature: priority of timers and competitive behavior
- New feature: System action to put playing device on standby via a CEC peripheral
- Fixed issue so that favourites can be scheduled again